### PR TITLE
Fix Ruby 1.9 related syntax issues in the crowbar.yml files. [4/5]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -19,7 +19,7 @@ barclamp:
   proposal_schema_version: 1
   version: 0
   requires:
-    - @crowbar
+    - '@crowbar'
     - git
     - mysql
     - rabbitmq


### PR DESCRIPTION
Ruby 1.9 barfs on some of the syntax in our crowbar.yml files due to
having a stricter notion of what is valid YML.

 crowbar.yml |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: ffc3762d231760e1644ae1583d71b1790716c46f

Crowbar-Release: feature/grizzly
