### PR TITLE
Make sure cinder installs python-mysqldb. [1/1]

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -73,6 +73,7 @@ if node[:cinder][:use_gitrepo]
   end
 else
   package "cinder-common"
+  package "python-mysqldb"
   package "python-cinder"
 end
 


### PR DESCRIPTION
We need python-mysqldb to talk to mysql.  We were not ensuring that it was installed.

 chef/cookbooks/cinder/recipes/common.rb |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: 0a1a9e20e427c9bfc484ab67eccfe7f77b2be2c8

Crowbar-Release: pebbles
