### PR TITLE
Get rid of git BC dependencies [3/3]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -20,7 +20,6 @@ barclamp:
   version: 0
   requires:
     - '@crowbar'
-    - git
     - mysql
     - rabbitmq
     - keystone


### PR DESCRIPTION
These barclamps can deploy without using PFS.  We no longer need git as a prereq.

 crowbar.yml |    1 -
 1 file changed, 1 deletion(-)

Crowbar-Pull-ID: 1054fa29f4d7a5fc61f0e32c91991d0d08f9668b

Crowbar-Release: pebbles
