### PR TITLE
Fixing description for OS barclamps [3/8]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -15,7 +15,7 @@
 barclamp:
   name: cinder
   display: Cinder
-  description: Openstack block storage: persistent block level storage devices for use with OpenStack compute instances
+  description: 'Openstack block storage: persistent block level storage devices for use with OpenStack compute instances'
   proposal_schema_version: 1
   version: 0
   requires:


### PR DESCRIPTION
Chnaged description for swift, glance, tempest, nova_dashboard, cinder, quantum and nova to match ones in OS.
Decsriptions for all these components are no defined in crowbar.yml instead of scattered between chef/data_bags and yml.

 crowbar.yml |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: b671718679ec72e1f12a8a35bc36e8d102d1772c

Crowbar-Release: pebbles
