### PR TITLE
Configure cinder and quantum to work with new database barclamp [1/2]

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -103,7 +103,11 @@ end
 sql_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(sql, "admin").address if sql_address.nil?
 Chef::Log.info("SQL server found at #{sql_address}")
 
+include_recipe "database::client"
 backend_name = Chef::Recipe::Database::Util.get_backend_name(sql)
+include_recipe "#{backend_name}::client"
+include_recipe "#{backend_name}::python-client"
+
 sql_connection = "#{backend_name}://#{node[:cinder][:db][:user]}:#{node[:cinder][:db][:password]}@#{sql_address}/#{node[:cinder][:db][:database]}"
 
 my_ipaddress = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address


### PR DESCRIPTION
Configure cinder and quantum to work with new database barclamp

Cinder needed some include_recipes to fix up it's common recipe, and 
quantum needed a dependency for database barclamp.

 chef/cookbooks/cinder/recipes/common.rb |    4 ++++
 1 file changed, 4 insertions(+)

Crowbar-Pull-ID: b05623bb4be0463dabf80598314488af022d36d6

Crowbar-Release: pebbles
