### PR TITLE
enforcing single proposal for all openstack barclamps [4/9]

### DIFF
--- a/crowbar_framework/app/models/cinder_service.rb
+++ b/crowbar_framework/app/models/cinder_service.rb
@@ -22,6 +22,11 @@ class CinderService < ServiceObject
 
   #if barclamp allows multiple proposals OVERRIDE
   # def self.allow_multiple_proposals?
+# Turn off multi proposal support till it really works and people ask for it.
+  def self.allow_multiple_proposals?
+    false
+  end
+
 
   def proposal_dependencies(role)
     answer = []


### PR DESCRIPTION
setup allow_multiple_proposals to false for cinder, database, glance, keystone, nova, nova_dashboard, quantum rabbitmq, and swift.

 crowbar_framework/app/models/cinder_service.rb |    5 +++++
 1 file changed, 5 insertions(+)

Crowbar-Pull-ID: 79c57cd7d40ba8de015310df1f8f9e8b30a9b020

Crowbar-Release: pebbles
