### PR TITLE
Add a (non-visible in UI) use_syslog attribute, defaulting to false

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -3,7 +3,7 @@ debug=<%= node[:cinder][:debug] %>
 verbose=<%= node[:cinder][:verbose] %>
 logdir=/var/log/cinder
 state_path=/var/lib/cinder
-use_syslog=true
+use_syslog=<%= node[:cinder][:use_syslog] ? "True" : "False" %>
 connection_type=libvirt
 sql_connection=<%= @sql_connection %>
 my_ip=<%= node[:cinder][:my_ip] %>

--- a/chef/data_bags/crowbar/bc-template-cinder.json
+++ b/chef/data_bags/crowbar/bc-template-cinder.json
@@ -5,6 +5,7 @@
     "cinder": {
       "debug": false,
       "verbose": false,
+      "use_syslog": false,
       "rabbitmq_instance": "none",
       "keystone_instance": "none",
       "glance_instance": "none",

--- a/chef/data_bags/crowbar/bc-template-cinder.schema
+++ b/chef/data_bags/crowbar/bc-template-cinder.schema
@@ -14,6 +14,7 @@
           "mapping": {
             "debug": { "type": "bool", "required": true },
             "verbose": { "type": "bool", "required": true },
+            "use_syslog": { "type": "bool", "required": true },
             "rabbitmq_instance": { "type": "str", "required": true },
             "keystone_instance": { "type": "str", "required": true },
             "database_instance": { "type": "str", "required": true },


### PR DESCRIPTION
We don't need to have cinder use the syslog by default, but as other
barclamps have an attribute to enable this, add this here too.
