### PR TITLE
Use new render_instance_selector helper and do not show service-related bits in UI

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -66,8 +66,6 @@ locale_additions:
           database_instance: Database Instance 
           keystone_instance: Keystone
           glance_instance: Glance
-          service_user: Service user (for Keystone)
-          service_password: Service password
           volume_header: Volume options
           volume_type: Type of Volume
           volume_name: Name of Volume

--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -10,12 +10,6 @@
     = render_instance_selector("keystone", :keystone_instance, t('.keystone_instance'), "keystone_instance", @proposal)
     = render_instance_selector("glance", :glance_instance, t('.glance_instance'), "glance_instance", @proposal)
     %p
-      %label{ :for => :service_user }= t('.service_user')
-      %input#service_user{:type => "text", :name => "service_user", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["service_user"], :onchange => "update_value('service_user','service_user', 'string')"}
-    %p
-      %label{ :for => :service_password }= t('.service_password')
-      %input#service_password{:type => "text", :name => "service_password", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["service_password"], :onchange => "update_value('service_password','service_password', 'string')"}
-    %p
       %label{ :for => :volume_header }= t('.volume_header')
     %div.container
       %p


### PR DESCRIPTION
For service-related bits: end users don't need to change this (and we already generate a random password); it can still be changed in the json if really needed.
