### PR TITLE
The keystone auth_token middleware has been move to keystoneclient [2/4]

### DIFF
--- a/chef/cookbooks/cinder/templates/default/api-paste.ini.erb
+++ b/chef/cookbooks/cinder/templates/default/api-paste.ini.erb
@@ -49,7 +49,7 @@ paste.app_factory = cinder.api.versions:Versions.factory
 paste.filter_factory = cinder.api.middleware.auth:CinderKeystoneContext.factory
 
 [filter:authtoken]
-paste.filter_factory = keystone.middleware.auth_token:filter_factory
+paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
 service_protocol = http
 service_host = <%= @keystone_ip_address %>
 service_port = <%= @keystone_service_port %>


### PR DESCRIPTION
Using keystone.middleware.auth_token causes problems on nodes that don't have
the server side of keystone installed.

 chef/cookbooks/cinder/templates/default/api-paste.ini.erb | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 197808408153b82a03525bc760b96ecadfb330c3

Crowbar-Release: pebbles
