### PR TITLE
Add non-configurable attribute for http/https use in keystone [3/7]

### DIFF
--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -34,6 +34,7 @@ else
 end
 
 keystone_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(keystone, "admin").address if keystone_address.nil?
+keystone_protocol = keystone["keystone"]["api"]["protocol"]
 keystone_token = keystone[:keystone][:service][:token]
 keystone_service_port = keystone[:keystone][:api][:service_port]
 keystone_admin_port = keystone[:keystone][:api][:admin_port]
@@ -58,6 +59,7 @@ public_api_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "pub
 admin_api_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
 
 keystone_register "cinder api wakeup keystone" do
+  protocol keystone_protocol
   host keystone_address
   port keystone_admin_port
   token keystone_token
@@ -65,6 +67,7 @@ keystone_register "cinder api wakeup keystone" do
 end
 
 keystone_register "register cinder user" do
+  protocol keystone_protocol
   host keystone_address
   port keystone_admin_port
   token keystone_token
@@ -75,6 +78,7 @@ keystone_register "register cinder user" do
 end
 
 keystone_register "give cinder user access" do
+  protocol keystone_protocol
   host keystone_address
   port keystone_admin_port
   token keystone_token
@@ -85,6 +89,7 @@ keystone_register "give cinder user access" do
 end
 
 keystone_register "register cinder service" do
+  protocol keystone_protocol
   host keystone_address
   port keystone_admin_port
   token keystone_token
@@ -95,6 +100,7 @@ keystone_register "register cinder service" do
 end
 
 keystone_register "register cinder endpoint" do
+  protocol keystone_protocol
   host keystone_address
   port keystone_admin_port
   token keystone_token
@@ -122,6 +128,7 @@ template "/etc/cinder/api-paste.ini" do
   group "root"
   mode "0640"
   variables(
+    :keystone_protocol => keystone_protocol,
     :keystone_ip_address => keystone_address,
     :keystone_admin_token => keystone_token,
     :keystone_service_port => keystone_service_port,

--- a/chef/cookbooks/cinder/templates/default/api-paste.ini.erb
+++ b/chef/cookbooks/cinder/templates/default/api-paste.ini.erb
@@ -50,12 +50,12 @@ paste.filter_factory = cinder.api.middleware.auth:CinderKeystoneContext.factory
 
 [filter:authtoken]
 paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
-service_protocol = http
+service_protocol = <%= @keystone_protocol %>
 service_host = <%= @keystone_ip_address %>
 service_port = <%= @keystone_service_port %>
 auth_host = <%= @keystone_ip_address %>
 auth_port = <%= @keystone_admin_port %>
-auth_protocol = http
+auth_protocol = <%= @keystone_protocol %>
 admin_tenant_name = <%= @keystone_service_tenant %>
 admin_user = <%= @keystone_service_user %>
 admin_password = <%= @keystone_service_password %>


### PR DESCRIPTION
In short: this doesn't change the current behavior, and is only a
preparatory commit for future SSL support in keystone.

This is set to http right now; this will enable other barclamps to use
this attribute without breaking them, and then we can make this
configurable.

Crowbar-Pull-ID: 4572857ca9291f4fab46772cbbe8ff0a06969160

Crowbar-Release: pebbles
