### PR TITLE
Fix setting of database password

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -112,6 +112,9 @@ backend_name = Chef::Recipe::Database::Util.get_backend_name(sql)
 include_recipe "#{backend_name}::client"
 include_recipe "#{backend_name}::python-client"
 
+::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
+node.set_unless['cinder']['db']['password'] = secure_password
+
 sql_connection = "#{backend_name}://#{node[:cinder][:db][:user]}:#{node[:cinder][:db][:password]}@#{sql_address}/#{node[:cinder][:db][:database]}"
 
 my_ipaddress = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address

--- a/chef/cookbooks/cinder/recipes/sql.rb
+++ b/chef/cookbooks/cinder/recipes/sql.rb
@@ -40,9 +40,6 @@ db_provider = Chef::Recipe::Database::Util.get_database_provider(sql)
 db_user_provider = Chef::Recipe::Database::Util.get_user_provider(sql)
 privs = Chef::Recipe::Database::Util.get_default_priviledges(sql)
 
-::Chef::Recipe.send(:include, Opscode::OpenSSL::Password)
-node.set_unless['cinder']['db']['password'] = secure_password
-
 sql_address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(sql, "admin").address if sql_address.nil?
 Chef::Log.info("Database server found at #{sql_address}")
 

--- a/crowbar_framework/app/models/cinder_service.rb
+++ b/crowbar_framework/app/models/cinder_service.rb
@@ -83,7 +83,6 @@ class CinderService < ServiceObject
     end
 
     base["attributes"]["cinder"]["service_password"] = '%012d' % rand(1e12)
-    base["attributes"]["cinder"]["db"]["password"] = random_password
 
     @logger.debug("Cinder create_proposal: exiting")
     base


### PR DESCRIPTION
First, do not set the database password in the crowbar service model if
it's not set, but leave the cookbook set it like we do in other
cookbooks (and like the cookbook was trying to do).

Second, set the correct password early, in the common recipe, before we
define the sql connection variable, instead of later on (in the database
recipe).

This fixes a crash on first run of the cookbook, as seen in
http://lists.us.dell.com/pipermail/crowbar/2013-June/003354.html
