### PR TITLE
Respect glance protocl in cinder.conf glance_api_servers

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -88,10 +88,14 @@ if glance_servers.length > 0
   glance_server = glance_servers[0]
   glance_server = node if glance_server.name == node.name
   glance_server_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(glance_server, "admin").address
+  glance_server_protocol = glance_server[:glance][:api][:protocol]
   glance_server_port = glance_server[:glance][:api][:bind_port]
+  glance_server_insecure = glance_server_protocol == 'https' && glance_server[:glance][:ssl][:insecure]
 else
   glance_server_ip = nil
   glance_server_port = nil
+  glance_server_protocol = nil
+  glance_server_insecure = nil
 end
 Chef::Log.info("Glance server at #{glance_server_ip}")
 
@@ -203,8 +207,10 @@ template "/etc/cinder/cinder.conf" do
             :manual_driver_config => manual_driver_config,
             :sql_connection => sql_connection,
             :rabbit_settings => rabbit_settings,
+            :glance_server_protocol => glance_server_protocol,
             :glance_server_ip => glance_server_ip,
-            :glance_server_port => glance_server_port
+            :glance_server_port => glance_server_port,
+            :glance_server_insecure => glance_server_insecure
             )
 end
 

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -97,7 +97,7 @@ my_ip=<%= node[:cinder][:my_ip] %>
 
 # A list of the glance api servers available to cinder
 # ([hostname|ip]:port) (list value)
-glance_api_servers=<%= @glance_server_ip %>:<%= @glance_server_port %>
+glance_api_servers=<%= @glance_server_protocol %>://<%= @glance_server_ip %>:<%= @glance_server_port %>
 
 # default version of the glance api to use
 #glance_api_version=1
@@ -108,7 +108,7 @@ glance_api_servers=<%= @glance_server_ip %>:<%= @glance_server_port %>
 
 # Allow to perform insecure SSL (https) requests to glance
 # (boolean value)
-#glance_api_insecure=false
+glance_api_insecure=<%= @glance_server_insecure %>
 
 # the topic scheduler nodes listen on (string value)
 #scheduler_topic=cinder-scheduler


### PR DESCRIPTION
Depends on crowbar/barclamp-glance#105
