### PR TITLE
Add a element_run_list_order to the cinder template

### DIFF
--- a/chef/data_bags/crowbar/bc-template-cinder.json
+++ b/chef/data_bags/crowbar/bc-template-cinder.json
@@ -138,6 +138,10 @@
           [ "cinder-controller" ],
           [ "cinder-volume" ]
       ],
+      "element_run_list_order": {
+          "cinder-controller": 92,
+          "cinder-volume": 93
+      },
       "config": {
         "environment": "cinder-base-config",
         "mode": "full",

--- a/chef/data_bags/crowbar/bc-template-cinder.schema
+++ b/chef/data_bags/crowbar/bc-template-cinder.schema
@@ -153,6 +153,16 @@
                 "sequence": [ { "type": "str" } ]
               } ]
             },
+            "element_run_list_order": {
+              "type": "map",
+              "required": false,
+              "mapping": {
+                = : {
+                  "type": "int",
+                  "required": true
+                }
+              }
+            },
             "config": {
               "type": "map",
               "required": true,

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -33,7 +33,7 @@ crowbar:
   layout: 1
   order: 92 
   run_order: 92
-  chef_order: 100
+  chef_order: 92
 
 debs:
   ubuntu-12.04:


### PR DESCRIPTION
To ensure that the -controller recipes always run before -volume. Otherwise the
order randomly changed and the proposal failed to apply sometimes.

https://bugzilla.novell.com/show_bug.cgi?id=828141
