### PR TITLE
Allocate public IP address to cinder-controller nodes

### DIFF
--- a/crowbar_framework/app/models/cinder_service.rb
+++ b/crowbar_framework/app/models/cinder_service.rb
@@ -89,5 +89,18 @@ class CinderService < ServiceObject
     base
   end
 
+  def apply_role_pre_chef_call(old_role, role, all_nodes)
+    @logger.debug("Cinder apply_role_pre_chef_call: entering #{all_nodes.inspect}")
+    return if all_nodes.empty?
+
+    net_svc = NetworkService.new @logger
+    tnodes = role.override_attributes["cinder"]["elements"]["cinder-controller"]
+    tnodes.each do |n|
+      net_svc.allocate_ip "default", "public", "host", n
+    end unless tnodes.nil?
+
+    @logger.debug("Cinder apply_role_pre_chef_call: leaving")
+  end
+
 end
 


### PR DESCRIPTION
The cinder server needs to be accessible from the external network, so
that OpenStack command line tools work.
