### PR TITLE
Register endpoints with public name and FQDN when possible

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -87,17 +87,17 @@ glance_servers = search(:node, "roles:glance-server#{glance_env_filter}") || []
 if glance_servers.length > 0
   glance_server = glance_servers[0]
   glance_server = node if glance_server.name == node.name
-  glance_server_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(glance_server, "admin").address
+  glance_server_host = glance_server[:fqdn]
   glance_server_protocol = glance_server[:glance][:api][:protocol]
   glance_server_port = glance_server[:glance][:api][:bind_port]
   glance_server_insecure = glance_server_protocol == 'https' && glance_server[:glance][:ssl][:insecure]
 else
-  glance_server_ip = nil
+  glance_server_host = nil
   glance_server_port = nil
   glance_server_protocol = nil
   glance_server_insecure = nil
 end
-Chef::Log.info("Glance server at #{glance_server_ip}")
+Chef::Log.info("Glance server at #{glance_server_host}")
 
 sql_env_filter = " AND database_config_environment:database-config-#{node[:cinder][:database_instance]}"
 sqls = search(:node, "roles:database-server#{sql_env_filter}")
@@ -223,7 +223,7 @@ template "/etc/cinder/cinder.conf" do
             :sql_connection => sql_connection,
             :rabbit_settings => rabbit_settings,
             :glance_server_protocol => glance_server_protocol,
-            :glance_server_ip => glance_server_ip,
+            :glance_server_host => glance_server_host,
             :glance_server_port => glance_server_port,
             :glance_server_insecure => glance_server_insecure
             )

--- a/chef/cookbooks/cinder/templates/default/api-paste.ini.erb
+++ b/chef/cookbooks/cinder/templates/default/api-paste.ini.erb
@@ -51,9 +51,9 @@ paste.filter_factory = cinder.api.middleware.auth:CinderKeystoneContext.factory
 [filter:authtoken]
 paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory
 service_protocol = <%= @keystone_protocol %>
-service_host = <%= @keystone_ip_address %>
+service_host = <%= @keystone_host %>
 service_port = <%= @keystone_service_port %>
-auth_host = <%= @keystone_ip_address %>
+auth_host = <%= @keystone_host %>
 auth_port = <%= @keystone_admin_port %>
 auth_protocol = <%= @keystone_protocol %>
 admin_tenant_name = <%= @keystone_service_tenant %>

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -97,7 +97,7 @@ my_ip=<%= node[:cinder][:my_ip] %>
 
 # A list of the glance api servers available to cinder
 # ([hostname|ip]:port) (list value)
-glance_api_servers=<%= @glance_server_protocol %>://<%= @glance_server_ip %>:<%= @glance_server_port %>
+glance_api_servers=<%= @glance_server_protocol %>://<%= @glance_server_host %>:<%= @glance_server_port %>
 
 # default version of the glance api to use
 #glance_api_version=1


### PR DESCRIPTION
When using SSL, the common name field in the certificates is checked,
and using IP addresses won't work with that.

Internally to the OpenStack setup, it is always fine to use the FQDN
from the node, so we use this in the internal and admin URLs of the
endpoints.

For the public URL, we prefer to use the public name if it is set. If it
it not set, then we use the public FQDN only if SSL is enabled;
otherwise, we prefer the IP address (like before) because we're not 100%
sure that the administrator will have completed a proper DNS setup where
the public FQDN generated by Crowbar will be announced externally.
