### PR TITLE
Stop installing python-keystone package

### DIFF
--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -52,8 +52,6 @@ if node[:cinder][:use_gitrepo]
     path File.join(cinder_path,"keystone")
     virtualenv venv_path
   end
-else
-  package "python-keystone"
 end
 
 my_admin_host = node[:fqdn]


### PR DESCRIPTION
This is not needed since commit 6921bbb, when we moved to using
keystoneclient.middleware.auth_token.
