### PR TITLE
webui: Only show local (or raw) options when local (or raw) is selected

### DIFF
--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -158,8 +158,8 @@
     $('div#netapp_parameters').toggle(choice == 'netapp');
     $('div#eqlx_parameters').toggle(choice == 'eqlx');
     $('div#manual_parameters').toggle(choice == 'manual');
-    $('div#volume_file_parameters').toggle(choice == 'raw' || choice == 'local');
-    $('div#volume_disk_parameters').toggle(choice == 'raw' || choice == 'local');
+    $('div#volume_file_parameters').toggle(choice == 'local');
+    $('div#volume_disk_parameters').toggle(choice == 'raw');
   }
 
   function toggle_protocol() {


### PR DESCRIPTION
Until now, we were always showing local and raw options when local or
raw was selected. They should only appear when the correct option is
selected.
