### PR TITLE
DE1381: Refactor Cinder volume create and management code to make it easier to debug. [1/1]

### DIFF
--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -116,7 +116,7 @@ when node[:cinder][:volume][:volume_type] == "eqlx"
   make_eqlx_volumes(node)
 when (node[:cinder][:volume][:volume_type] == "local") ||
     (unclaimed_disks.empty? && claimed_disks.empty?)
-  make_local_volume(node,volname)
+  make_loopback_volume(node,volname)
 when node[:cinder][:volume][:volume_type] == "raw"
   make_volume(node,volname,unclaimed_disks,claimed_disks)
 end


### PR DESCRIPTION
In DE1381, Cinder tried to grab a disk that was already claimed as the
boot device.  It is not obvious how it managed that, but the code was
a bit of a ball of spaghetti.  This code de-spaghettifies the flow of
control to make debugging simpler without affecting overall
functionality.

 chef/cookbooks/cinder/recipes/volume.rb |  143 ++++++++++++++++---------------
 1 file changed, 73 insertions(+), 70 deletions(-)

Crowbar-Pull-ID: 372850d7ee40fa05f9fc6a185c0dcefe2331a08a

Crowbar-Release: mesa-1.6
