### PR TITLE
Make NetApp driver Mode configurable in UI

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -800,30 +800,65 @@ volume_group=<%= node[:cinder][:volume][:volume_name] %>
 
 # URL of the WSDL file for the DFM server (string value)
 #netapp_wsdl_url=<None>
+<% unless @netapp_params.nil? -%>
+netapp_wsdl_url=<%= @netapp_params['netapp_wsdl_url'] %>
+<% end -%>
 
 # User name for the DFM server (string value)
 #netapp_login=<None>
+<% unless @netapp_params.nil? -%>
+netapp_login=<%= @netapp_params['netapp_login'] %>
+<% end -%>
 
 # Password for the DFM server (string value)
 #netapp_password=<None>
+<% unless @netapp_params.nil? -%>
+netapp_password=<%= @netapp_params['netapp_password'] %>
+<% end -%>
 
 # Hostname for the DFM server (string value)
 #netapp_server_hostname=<None>
+<% unless @netapp_params.nil? -%>
+netapp_server_hostname=<%= @netapp_params['netapp_server_hostname'] %>
+<% end -%>
 
 # Port number for the DFM server (integer value)
 #netapp_server_port=8088
+<% unless @netapp_params.nil? -%>
+netapp_server_port=<%= @netapp_params['netapp_server_port'] %>
+<% end -%>
+
+# Transport type for the DFM server (string value)
+#netapp_transport_type=http|https
+<% unless @netapp_params.nil? -%>
+netapp_transport_type=<%= @netapp_params['netapp_transport_type'] %>
+<% end -%>
+
+# Comma separated volumes to be used for provisioning
+#netapp_volume_list=None
+<% unless @netapp_params.nil? -%>
+netapp_volume_list=<%= @netapp_params['netapp_volume_list'] %>
+<% end -%>
 
 # Storage service to use for provisioning (when
 # volume_type=None) (string value)
 #netapp_storage_service=<None>
+<% unless @netapp_params.nil? -%>
+netapp_storage_service=<%= @netapp_params['netapp_storage_service'] %>
+<% end -%>
 
 # Prefix of storage service name to use for provisioning
 # (volume_type name will be appended) (string value)
 #netapp_storage_service_prefix=<None>
+<% unless @netapp_params.nil? -%>
+netapp_storage_service_prefix=<%= @netapp_params['netapp_storage_service_prefix'] %>
+<% end -%>
 
 # Vfiler to use for provisioning (string value)
 #netapp_vfiler=<None>
-
+<% unless @netapp_params.nil? -%>
+netapp_vfiler=<%= @netapp_params['netapp_vfiler'] %>
+<% end -%>
 
 #
 # Options defined in cinder.volume.drivers.netapp_nfs
@@ -1171,10 +1206,7 @@ volume_driver=cinder.volume.eqlx.DellEQLSanISCSIDriver
 <% end -%>
 
 <% unless @netapp_params.nil? -%>
-volume_driver=cinder.volume.drivers.netapp.iscsi.NetAppISCSIDriver
-<%   @netapp_params.each do |k, v| -%>
-<%=    k + '=' + v.to_s %>
-<%   end -%>
+volume_driver=<%= @netapp_params['netapp_driver'] %>
 <% end -%>
 
 <% unless @emc_params.nil? -%>

--- a/chef/data_bags/crowbar/bc-template-cinder.json
+++ b/chef/data_bags/crowbar/bc-template-cinder.json
@@ -92,15 +92,16 @@
           "eqlx_pool": "default"
         },
         "netapp": {
+          "netapp_driver": "cinder.volume.drivers.netapp.iscsi.NetAppDirect7modeISCSIDriver",
           "netapp_wsdl_url": "http://192.168.124.11:8088/",
           "netapp_server_hostname": "192.168.124.11",
-          "netapp_server_port": 8088,
+          "netapp_server_port": 443,
           "netapp_login": "admin",
           "netapp_password": "admin",
           "netapp_storage_service": "",
           "netapp_storage_service_prefix": "crowbar_",
           "netapp_vfiler": "",
-          "netapp_transport_type": "http",
+          "netapp_transport_type": "https",
           "netapp_volume_list": ""
         },
         "emc": {

--- a/chef/data_bags/crowbar/bc-template-cinder.schema
+++ b/chef/data_bags/crowbar/bc-template-cinder.schema
@@ -54,6 +54,7 @@
                   "type": "map",
                   "required": true,
                   "mapping": {
+                    "netapp_driver": { "type": "str", "required": true},
                     "netapp_wsdl_url": { "type": "str", "required": true },
                     "netapp_server_hostname": { "type": "str", "required": true },
                     "netapp_server_port": { "type": "int", "required": true },

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -85,15 +85,18 @@ locale_additions:
           ecom_server_port: Port of the ECOM server
           ecom_server_username: Username for accessing the ECOM server
           ecom_server_password: Password for accessing the ECOM server
+          netapp_driver: NetApp Driver Mode
           netapp_parameters: NetApp Parameters
           netapp_wsdl_url: WSDL URL for NetApp OnCommand Webservices
-          netapp_server_hostname: OnCommand server host name
-          netapp_server_port: OnCommand server port to connect to
-          netapp_login: Login user name for OnCommand installation
-          netapp_password: Login password for OnCommand installation
+          netapp_server_hostname: Server host name
+          netapp_server_port: Server port
+          netapp_login: Login user name
+          netapp_password: Login password
+          netapp_transport_type: NetApp Transport Type
           netapp_storage_service: Storage service to use while provisioning
           netapp_storage_service_prefix: Storage service prefix to use on OnCommand
           netapp_vfiler: The vFiler unit name if using vFiler to host OpenStack volumes
+          netapp_volume_list: Comma separated volume list for provisioning
           eqlx_parameters: EqualLogic Parameters
           eqlx_san_ip: EQLX SAN IP
           eqlx_san_login: EQLX SAN login

--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -23,11 +23,18 @@
           %label{ :for => :netappp_header }= t('.netapp_parameters')
         %div.container
           %p
-            %label{ :for => :netapp_wsdl_url }= t('.netapp_wsdl_url')
-            %input#netapp_wsdl_url{:type => "text", :name => "netapp_wsdl_url", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["netapp"]["netapp_wsdl_url"], :onchange => "update_value('volume/netapp/netapp_wsdl_url', 'netapp_wsdl_url', 'string')"}
+            %label{ :for => :netapp_driver }= t('.netapp_driver')
+            = select_tag :netapp_driver, options_for_select([['7-Mode iSCSI direct driver', 'cinder.volume.drivers.netapp.iscsi.NetAppDirect7modeISCSIDriver'],
+                ['7-Mode NFS direct driver', 'cinder.volume.drivers.netapp.nfs.NetAppDirect7modeNfsDriver'],
+                ['iSCSI direct driver for clustered Data ONTAP', 'cinder.volume.drivers.netapp.iscsi.NetAppDirectCmodeISCSIDriver'],
+                ['NFS direct driver for clustered Data ONTAP', 'cinder.volume.drivers.netapp.nfs.NetAppDirectCmodeNfsDriver'],
+            ], @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["netapp"]["netapp_driver"].to_s), :onchange => "update_value('volume/netapp/netapp_driver', 'netapp_driver', 'string')"
           %p
             %label{ :for => :netapp_server_hostname }= t('.netapp_server_hostname')
             %input#netapp_server_hostname{:type => "text", :name => "netapp_server_hostname", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["netapp"]["netapp_server_hostname"], :onchange => "update_value('volume/netapp/netapp_server_hostname', 'netapp_server_hostname', 'string')"}
+          %p
+            %label{ :for => :netapp_transport_type }= t('.netapp_transport_type')
+            = select_tag :netapp_transport_type, options_for_select([['HTTP','http'], ['HTTPS', 'https']], @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["netapp"]["netapp_transport_type"].to_s), :onchange => "update_value('volume/netapp/netapp_transport_type', 'netapp_transport_type', 'string')"
           %p
             %label{ :for => :netapp_server_port }= t('.netapp_server_port')
             %input#netapp_server_port{:type => "text", :name => "netapp_server_port", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["netapp"]["netapp_server_port"], :onchange => "update_value('volume/netapp/netapp_server_port', 'netapp_server_port', 'integer')"}
@@ -37,9 +44,6 @@
           %p
             %label{ :for => :netapp_password }= t('.netapp_password')
             %input#netapp_password{:type => "password", :name => "netapp_password", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["netapp"]["netapp_password"], :onchange => "update_value('volume/netapp/netapp_password', 'netapp_password', 'string')"}
-          %p
-            %label{ :for => :netapp_storage_service_prefix }= t('.netapp_storage_service_prefix')
-            %input#netapp_storage_service_prefix{:type => "text", :name => "netapp_storage_service_prefix", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["netapp"]["netapp_storage_service_prefix"], :onchange => "update_value('volume/netapp/netapp_storage_service_prefix', 'netapp_storage_service_prefix', 'string')"}
           %p
             %label{ :for => :netapp_storage_service }= t('.netapp_storage_service')
             %input#netapp_storage_service{:type => "text", :name => "netapp_storage_service", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["netapp"]["netapp_storage_service"], :onchange => "update_value('volume/netapp/netapp_storage_service', 'netapp_storage_service', 'string')"}


### PR DESCRIPTION
Add Options for configuring the NetApp direct
driver mode (either NFS or iSCSI). Hide the
OnCommand related options from the UI.
