### PR TITLE
Allow to auto-generate self-signed SSL certificates

### DIFF
--- a/chef/cookbooks/cinder/attributes/default.rb
+++ b/chef/cookbooks/cinder/attributes/default.rb
@@ -28,8 +28,9 @@ node[:cinder][:monitor][:ports]={}
 
 default[:cinder][:api][:protocol] = "http"
 
-default[:cinder][:ssl][:insecure] = false
 default[:cinder][:ssl][:certfile] = "/etc/cinder/ssl/certs/signing_cert.pem"
 default[:cinder][:ssl][:keyfile] = "/etc/cinder/ssl/private/signing_key.pem"
+default[:cinder][:ssl][:generate_certs] = false
+default[:cinder][:ssl][:insecure] = false
 default[:cinder][:ssl][:cert_required] = false
 default[:cinder][:ssl][:ca_certs] = "/etc/cinder/ssl/certs/ca.pem"

--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -195,6 +195,54 @@ else
 end
 
 if node[:cinder][:api][:protocol] == 'https'
+  if node[:cinder][:ssl][:generate_certs]
+    package "openssl"
+
+    require "fileutils"
+    [:certfile, :keyfile, :ca_certs].each do |k|
+      dir = File.dirname(node[:cinder][:ssl][k])
+      if File.exists?(dir)
+        FileUtils.chown_R node[:cinder][:user], node[:cinder][:group], dir
+      else
+        FileUtils.mkdir_p(dir) {|d| File.chown node[:cinder][:user], node[:cinder][:group], d}
+      end
+    end
+
+    # Some more ownership fixes:
+    conf_dir = File.dirname node[:cinder][:ssl][:ca_certs]
+    FileUtils.chown "root", node[:cinder][:group], conf_dir
+    FileUtils.chown "root", node[:cinder][:group], File.expand_path("#{conf_dir}/..")  # /etc/cinder/ssl
+
+    # Generate private key
+    %x(openssl genrsa -out #{node[:cinder][:ssl][:keyfile]} 4096)
+    if $?.exitstatus != 0
+      message = "SSL private key generation failed"
+      Chef::Log.fatal(message)
+      raise message
+    end
+    FileUtils.chown node[:cinder][:user], node[:cinder][:group], node[:cinder][:ssl][:keyfile]
+
+    # Generate certificate signing requests (CSR)
+    ssl_csr_file = "#{conf_dir}/signing_key.csr"
+    ssl_subject = "\"/C=US/ST=Unset/L=Unset/O=Unset/CN=#{node[:fqdn]}\""
+    %x(openssl req -new -key #{node[:cinder][:ssl][:keyfile]} -out #{ssl_csr_file} -subj #{ssl_subject})
+    if $?.exitstatus != 0
+      message = "SSL certificate signed requests generation failed"
+      Chef::Log.fatal(message)
+      raise message
+    end
+
+    # Generate self-signed certificate with above CSR
+    %x(openssl x509 -req -days 3650 -in #{ssl_csr_file} -signkey #{node[:cinder][:ssl][:keyfile]} -out #{node[:cinder][:ssl][:certfile]})
+    if $?.exitstatus != 0
+      message = "SSL self-signed certificate generation failed"
+      Chef::Log.fatal(message)
+      raise message
+    end
+
+    File.delete ssl_csr_file  # Nobody should even try to use this
+  end
+
   unless ::File.exists? node[:cinder][:ssl][:certfile]
     message = "Certificate \"#{node[:cinder][:ssl][:certfile]}\" is not present."
     Chef::Log.fatal(message)

--- a/chef/data_bags/crowbar/bc-template-cinder.json
+++ b/chef/data_bags/crowbar/bc-template-cinder.json
@@ -121,9 +121,10 @@
         "bind_port": 8776
       },
       "ssl": {
-        "insecure": false,
         "certfile": "/etc/cinder/ssl/certs/signing_cert.pem",
         "keyfile": "/etc/cinder/ssl/private/signing_key.pem",
+        "generate_certs": false,
+        "insecure": false,
         "cert_required": false,
         "ca_certs": "/etc/cinder/ssl/certs/ca.pem"
       },

--- a/chef/data_bags/crowbar/bc-template-cinder.schema
+++ b/chef/data_bags/crowbar/bc-template-cinder.schema
@@ -100,9 +100,10 @@
               }
             },
             "ssl": { "type": "map", "required": true, "mapping": {
-              "insecure": { "type" : "bool", "required" : true },
               "certfile": { "type" : "str", "required" : true },
               "keyfile": { "type" : "str", "required" : true },
+              "generate_certs": { "type" : "bool", "required" : true },
+              "insecure": { "type" : "bool", "required" : true },
               "cert_required": { "type" : "bool", "required" : true },
               "ca_certs": { "type" : "str", "required" : true }
             }},

--- a/crowbar.yml
+++ b/crowbar.yml
@@ -115,6 +115,7 @@ locale_additions:
           ssl_insecure: SSL Certificate is insecure (for instance, auto-signed)
           ssl_certfile: SSL Certificate File
           ssl_keyfile: SSL (Private) Key File
+          ssl_generate_certs: Generate (self-signed) certificates (implies insecure)
           ssl_cert_required: Require Client Certificate
           ssl_ca_certs: SSL CA Certificates File
       cinder_edit_deployment:

--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -140,6 +140,9 @@
         %label{ :for => :ssl_keyfile }= t('.ssl_keyfile')
         = text_field_tag :ssl_keyfile, @proposal.raw_data['attributes'][@proposal.barclamp]["ssl"]["keyfile"], :size => 80, :onchange => "update_value('ssl/keyfile', 'ssl_keyfile', 'string')"
       %p
+        %label{ :for => :ssl_generate_certs }= t('.ssl_generate_certs')
+        = select_tag :ssl_generate_certs, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["ssl"]["generate_certs"].to_s), :onchange => "update_value('ssl/generate_certs', 'ssl_generate_certs', 'boolean')"
+      %p
         %label{ :for => :ssl_insecure }= t('.ssl_insecure')
         = select_tag :ssl_insecure, options_for_select([['true','true'], ['false', 'false']], @proposal.raw_data['attributes'][@proposal.barclamp]["ssl"]["insecure"].to_s), :onchange => "update_value('ssl/insecure', 'ssl_insecure', 'boolean')"
       %p
@@ -178,11 +181,20 @@
     }
   };
 
+  function toggle_ssl_generate_certs() {
+    if ($('#ssl_generate_certs option:selected').attr('value') == 'true') {
+      $('#ssl_insecure').attr('value', 'true');
+      $('#ssl_cert_required').attr('value', 'false');
+    }
+  };
+
   $(document).ready(function(){
     update_volume_type_view();
     toggle_protocol();
     toggle_ssl_cert_required();
+    toggle_ssl_generate_certs();
   });
 
   $('#protocol').change(toggle_protocol);
   $('#ssl_cert_required').change(toggle_ssl_cert_required);
+  $('#ssl_generate_certs').change(toggle_ssl_generate_certs);


### PR DESCRIPTION
The setup is rather simple. Instead of a full-blown CA, a CSR is used to
create the self-signed certificate.
