### PR TITLE
Mark volumes claimed by cinder as "removable"

### DIFF
--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -111,6 +111,7 @@ def make_volumes(node,volname)
     claimed_disks = unclaimed_disks.select do |d|
       if d.claim("Cinder")
         Chef::Log.info("Cinder: Claimed #{d.name}")
+        node[:cinder][:volume][:removable] = "1"
         true
       else
         Chef::Log.info("Cinder: Ignoring #{d.name}")


### PR DESCRIPTION
Volumes attached to nodes with the cinder barclamp are marked as removable
now. This prevents swift from claiming these volumes, witch will cause the
swift proposal to fail.

SUSE-internally tracked as bnc#826569
