### PR TITLE
CES-336 Fix cinder not to fall silently to local mode if no disks are available [1/1]

### DIFF
--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -81,7 +81,7 @@ def make_volume(node,volname,unclaimed_disks,claimed_disks)
   Chef::Log.info("Cinder: Using raw disks for volume backing.")
   if (unclaimed_disks.empty? && claimed_disks.empty?)
     Chef::Log.fatal("There are no suitable disks for cinder")
-    raise "There is no suitable disks for cinder"
+    raise "There are no suitable disks for cinder"
   elsif claimed_disks.empty?
     claimed_disks = if node[:cinder][:volume][:cinder_raw_method] == "first"
                       [unclaimed_disks.first]


### PR DESCRIPTION
If no disks are availble on any volume node and type is raw report an error "no suitable disks availabl" and not not silently fall into local mode on a node.

 chef/cookbooks/cinder/recipes/volume.rb |    8 +++++---
 1 file changed, 5 insertions(+), 3 deletions(-)

Crowbar-Pull-ID: 25b6af0832eba8fb161b05a80462d3ee19aa2d6d

Crowbar-Release: mesa-1.6.1
