### PR TITLE
Fixed typo 'scheduler' in javascript that was breaking node selector drag and drop for cinder-scheduler role [2/2]

### DIFF
--- a/crowbar_framework/app/views/barclamp/cinder/_edit_deployment.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_deployment.html.haml
@@ -6,7 +6,7 @@
   $(document).ready(function(){
     var constraints = { 
       "cinder-api": { "unique": false, "count": 1, "admin":false },
-      "cinder-sceduler": { "unique": false, "count": 1, "admin":false },
+      "cinder-scheduler": { "unique": false, "count": 1, "admin":false },
       "cinder-volume": { "unique": false, "count": -1, "admin":false }
     };
     node_selector($('#drag_drop'), constraints);


### PR DESCRIPTION
 .../barclamp/cinder/_edit_deployment.html.haml     |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: a245d2edf083255e8bd97b834398b39236a1f55c

Crowbar-Release: mesa-1.6.1
