### PR TITLE
Fix cinder.conf when using manual driver configuration

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -1216,6 +1216,7 @@ cinder_emc_config_file = /etc/cinder/cinder_emc_config.xml
 
 <% unless @manual_driver.nil? -%>
 volume_driver=<%= @manual_driver -%>
+
 <%= @manual_driver_config -%>
 <% end -%>
 


### PR DESCRIPTION
The first line of the option was put on the volume_driver line too,
which obviously broke cinder. Adding the empty line in the template
results in what we expect.
