### PR TITLE
remove first as an option for raw disks [1/1]

### DIFF
--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -79,7 +79,7 @@
         %label{ :for => :raw_header }= t('.volume_disk_parameters')
         %div.container
           %label{ :for => :cinder_raw_method }= t('.volume_raw_mode')
-          = select_tag :cinder_raw_method, options_for_select([['first','first'], ['all', 'all']], @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["cinder_raw_method"].to_s), :onchange => "update_value('volume/cinder_raw_method', 'cinder_raw_method', 'string')"
+          = select_tag :cinder_raw_method, options_for_select([['all', 'all']], @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["cinder_raw_method"].to_s), :onchange => "update_value('volume/cinder_raw_method', 'cinder_raw_method', 'string')"
     = render 'barclamp/git/pfsdeps.html.haml'
 
 


### PR DESCRIPTION
Remove "first"an an option for raw disks.
Users can still specify that option in raw mode.

 .../barclamp/cinder/_edit_attributes.html.haml     |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 2055d1813ff072b09cc51722980200ca27ced197

Crowbar-Release: mesa-1.6.1
