### PR TITLE
Fix cinder dependency for qemu-utils [1/1]

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -53,6 +53,7 @@ debs:
     - cinder-volume
     - python-cinder
     - python-keystone
+    - qemu-utils
 
 locale_additions:
   en:


### PR DESCRIPTION
Cinder has dependency on qemu-utils.
When cinder was part of nova or when nova is deployed on the same node as cinder it is not an issue.
But when cinder-volume is deployed on a node where is no nova some operations, like volume attach, are not functional.

 crowbar.yml |    1 +
 1 file changed, 1 insertion(+)

Crowbar-Pull-ID: 4afdf552623bb4a22eccbb556242137d37b97d60

Crowbar-Release: mesa-1.6.1
