### PR TITLE
qemu-utils dependency installation for cinder-scheduler [1/1]

### DIFF
--- a/chef/cookbooks/cinder/recipes/scheduler.rb
+++ b/chef/cookbooks/cinder/recipes/scheduler.rb
@@ -19,6 +19,8 @@
 
 include_recipe "#{@cookbook_name}::common"
 
-package_name "qemu-utils" if node.platform == "ubuntu"
+if node.platform == "ubuntu"
+ package "qemu-utils"
+end
 
 cinder_service("scheduler")


### PR DESCRIPTION
Install dependent package for cinder scheduler.
Current fix is for ubuntu only.

 chef/cookbooks/cinder/recipes/scheduler.rb |    4 ++++
 1 file changed, 4 insertions(+)

Crowbar-Pull-ID: cfb36561700ef0ee9809d61082ada9618013690a

Crowbar-Release: mesa-1.6.1
