### PR TITLE
Mesa-1.6.1 fix porting - remove First option for raw disks from UI (still supported in raw mode) [1/1]

### DIFF
--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -129,7 +129,7 @@
       %label.section-header{ :for => :volume_disk_div }= t('.volume_disk_parameters')
       %div.section{ :id => :volume_disk_div }
         %label{ :for => :cinder_raw_method }= t('.volume_raw_mode')
-        = select_tag :cinder_raw_method, options_for_select([['first','first'], ['all', 'all']], @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["cinder_raw_method"].to_s), :onchange => "update_value('volume/cinder_raw_method', 'cinder_raw_method', 'string')"
+        = select_tag :cinder_raw_method, options_for_select([['all', 'all']], @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["cinder_raw_method"].to_s), :onchange => "update_value('volume/cinder_raw_method', 'cinder_raw_method', 'string')"
         %p
           %label{ :for => :volume_name_disk }= t('.volume_name')
           %input.volume_name#volume_name_disk{:type => "text", :name => "volume_name_disk", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["volume_name"], :onchange => "update_value('volume/volume_name','volume_name_disk', 'string')"}


### PR DESCRIPTION
Forward porting removal of "first" option for raw disks selection in cinder UI.
First is misleading since it is the first available which is dynamicly changing.
It is still supported in raw mode.

 .../barclamp/cinder/_edit_attributes.html.haml     |    2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)

Crowbar-Pull-ID: 981f6b4a3aa1a85ba93a6cffe8eac19297a9ae81

Crowbar-Release: roxy
