### PR TITLE
propose cinder services for controller and/or storage node

### DIFF
--- a/crowbar_framework/app/models/cinder_service.rb
+++ b/crowbar_framework/app/models/cinder_service.rb
@@ -43,11 +43,11 @@ class CinderService < ServiceObject
     nodes = NodeObject.all
     nodes.delete_if { |n| n.nil? or n.admin? }
     if nodes.size >= 1
-      controller        = nodes.detect { |n| n if n.intended_role == "controller"} || nodes.first[:fqdn]
-      storage           = nodes.detect { |n| n if n.intended_role == "storage" } || controller
+      controller        = nodes.detect { |n| n.intended_role == "controller"} || nodes.first
+      storage           = nodes.detect { |n| n.intended_role == "storage" } || controller
       base["deployment"]["cinder"]["elements"] = {
-        "cinder-controller"     => [ controller ],
-        "cinder-volume"         => [ storage ]
+        "cinder-controller"     => [ controller[:fqdn] ],
+        "cinder-volume"         => [ storage[:fqdn] ]
       }
     end
 


### PR DESCRIPTION
Use the intended role set for the nodes to propose cinder deployment.
(Requires changes in barclamp-crowbar: https://github.com/crowbar/barclamp-crowbar/pull/796)
