### PR TITLE
Always enable boot.lvm on Cinder-volume nodes

### DIFF
--- a/chef/cookbooks/cinder/definitions/cinder_service.rb
+++ b/chef/cookbooks/cinder/definitions/cinder_service.rb
@@ -1,7 +1,7 @@
 define :cinder_service, :virtualenv => nil do
 
   cinder_name="cinder-#{params[:name]}"
-  cinder_name="openstack-cinder-#{params[:name]}" if %w(redhat centos suse).include?(node.platform)
+  cinder_name="openstack-cinder-#{params[:name]}" if %w(redhat centos suse).include? node.platform
 
   cinder_path = "/opt/cinder"
   venv_path = node[:cinder][:use_virtualenv] ? "#{cinder_path}/.venv" : nil
@@ -15,7 +15,7 @@ define :cinder_service, :virtualenv => nil do
     #TODO(agordeev):
     # be carefull, dpkg will not overwrite upstart configs
     # even if it be asked about that by 'confnew' option
-    package cinder_name unless %w(redhat centos).include?(node.platform)
+    package cinder_name unless %w(redhat centos).include? node.platform
   end
 
   service cinder_name do

--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -72,7 +72,7 @@ if node[:cinder][:use_gitrepo]
     not_if {File.exists?("/etc/cinder/rootwrap.d")}
   end
 else
-  unless %w(redhat centos suse).include?(node.platform)
+  unless %w(redhat centos suse).include? node.platform
     package "cinder-common"
     package "python-mysqldb"
     package "python-cinder"

--- a/chef/cookbooks/cinder/recipes/monitor.rb
+++ b/chef/cookbooks/cinder/recipes/monitor.rb
@@ -4,9 +4,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,7 +26,7 @@ svcs = node[:cinder][:monitor][:svcs]
 ports = node[:cinder][:monitor][:ports]
 log ("will monitor cinder svcs: #{svcs.join(',')} and ports #{ports.values.join(',')}")
 
-include_recipe "nagios::common" if node["roles"].include?("nagios-client")
+include_recipe "nagios::common" if node["roles"].include? "nagios-client"
 
 template "/etc/nagios/nrpe.d/cinder_nrpe.cfg" do
   source "cinder_nrpe.cfg.erb"
@@ -36,7 +36,7 @@ template "/etc/nagios/nrpe.d/cinder_nrpe.cfg" do
   variables( {
     :svcs => svcs ,
     :ports => ports
-  })    
+  })
    notifies :restart, "service[nagios-nrpe-server]"
-end if node["roles"].include?("nagios-client")    
+end if node["roles"].include? "nagios-client"
 

--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -147,7 +147,7 @@ end
 
 make_volumes(node,volname)
 
-unless %w(redhat centos).include?(node.platform)
+unless %w(redhat centos).include? node.platform
  package "tgt"
 else
  package "scsi-target-utils"
@@ -160,10 +160,10 @@ if node[:cinder][:use_gitrepo]
   cookbook_file "/etc/tgt/conf.d/cinder-volume.conf" do
     source "cinder-volume.conf"
   end
-elsif %w(redhat centos suse).include?(node.platform)
+elsif %w(redhat centos suse).include? node.platform
   cookbook_file "/etc/tgt/targets.conf" do
     source "cinder-volume.conf"
-    notifies :restart, "service[tgt]" if %w(redhat centos).include?(node.platform)
+    notifies :restart, "service[tgt]" if %w(redhat centos).include? node.platform
   end
 end
 
@@ -177,7 +177,7 @@ cinder_service("volume")
 
 # Restart doesn't work correct for this service.
 bash "restart-tgt_#{@cookbook_name}" do
-  unless %w(redhat centos suse).include?(node.platform)
+  unless %w(redhat centos suse).include? node.platform
     code <<-EOH
       stop tgt
       start tgt
@@ -191,6 +191,6 @@ end
 service "tgt" do
   supports :status => true, :restart => true, :reload => true
   action :enable
-  service_name "tgtd" if %w(redhat centos suse).include?(node.platform)
+  service_name "tgtd" if %w(redhat centos suse).include? node.platform
   notifies :run, "bash[restart-tgt_#{@cookbook_name}]"
 end


### PR DESCRIPTION
For LVM backend, we need lvm auto-activation to be running on
boot, otherwise cinder volumes are dead after a reboot of the
node. This is disabled on SLES by default, so we need to
activate the appropriate boot script.
