### PR TITLE
Readd and make "Grab first disk" option for Cinder RAW Mode

### DIFF
--- a/chef/data_bags/crowbar/bc-template-cinder.json
+++ b/chef/data_bags/crowbar/bc-template-cinder.json
@@ -75,7 +75,7 @@
       "volume": {
         "volume_name": "cinder-volumes",
         "volume_type": "raw",
-        "cinder_raw_method": "all",
+        "cinder_raw_method": "first",
         "local_file": "/var/lib/cinder/volume.raw",
         "local_size": 2000,
         "eqlx": {

--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -128,7 +128,7 @@
       %label.section-header{ :for => :volume_disk_div }= t('.volume_disk_parameters')
       %div.section{ :id => :volume_disk_div }
         %label{ :for => :cinder_raw_method }= t('.volume_raw_mode')
-        = select_tag :cinder_raw_method, options_for_select([['all', 'all']], @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["cinder_raw_method"].to_s), :onchange => "update_value('volume/cinder_raw_method', 'cinder_raw_method', 'string')"
+        = select_tag :cinder_raw_method, options_for_select([['First Available','first'], ['All Available', 'all']], @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["cinder_raw_method"].to_s), :onchange => "update_value('volume/cinder_raw_method', 'cinder_raw_method', 'string')"
         %p
           %label{ :for => :volume_name_disk }= t('.volume_name')
           %input.volume_name#volume_name_disk{:type => "text", :name => "volume_name_disk", :'data-default' => @proposal.raw_data['attributes'][@proposal.barclamp]["volume"]["volume_name"], :onchange => "update_value('volume/volume_name','volume_name_disk', 'string')"}


### PR DESCRIPTION
We usually do not want Cinder to grab additional disks that appear
on the cinder node, as those might be locally mapped LUNs and other
things totally unrelated to Crowbar. Grab first disk only by default.
