### PR TITLE
Run cinder-manage as the cinder user

### DIFF
--- a/chef/cookbooks/cinder/recipes/sql.rb
+++ b/chef/cookbooks/cinder/recipes/sql.rb
@@ -82,7 +82,7 @@ execute "cinder-manage db sync" do
   group node[:cinder][:group]
   command "#{venv_prefix}cinder-manage db sync"
   action :run
-end
+end unless %w(suse).include? node.platform
 
 # save data so it can be found by search
 node.save


### PR DESCRIPTION
Otherwise, it writes a cinder-manage.log as root, which can possibly
break other bits (at least on SUSE).
