### PR TITLE
Adding ability to send "volume" and "volume.size" metrics to Ceilometer.

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -207,7 +207,7 @@ auth_strategy=keystone
 
 # AMQP exchange to connect to if using RabbitMQ or Qpid
 # (string value)
-#control_exchange=cinder
+control_exchange=cinder
 
 
 #
@@ -454,6 +454,8 @@ logdir=/var/log/cinder
 #
 # Options defined in cinder.openstack.common.notifier.rabbit_notifier
 #
+
+notification_driver=cinder.openstack.common.notifier.rabbit_notifier
 
 # AMQP topic used for openstack notifications (list value)
 #notification_topics=notifications


### PR DESCRIPTION
This pool request enables:  https://github.com/crowbar/barclamp-ceilometer/pull/51
