### PR TITLE
Port Cinder configuration for NetApp to Havana

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -794,70 +794,70 @@ volume_group=<%= node[:cinder][:volume][:volume_name] %>
 #lvm_mirrors=0
 
 
+<% unless @netapp_params.nil? -%>
 #
-# Options defined in cinder.volume.drivers.netapp
+# Options defined in cinder.volume.drivers.netapp.options
 #
 
-# URL of the WSDL file for the DFM server (string value)
-#netapp_wsdl_url=<None>
-<% unless @netapp_params.nil? -%>
-netapp_wsdl_url=<%= @netapp_params['netapp_wsdl_url'] %>
-<% end -%>
-
-# User name for the DFM server (string value)
-#netapp_login=<None>
-<% unless @netapp_params.nil? -%>
-netapp_login=<%= @netapp_params['netapp_login'] %>
-<% end -%>
-
-# Password for the DFM server (string value)
-#netapp_password=<None>
-<% unless @netapp_params.nil? -%>
-netapp_password=<%= @netapp_params['netapp_password'] %>
-<% end -%>
-
-# Hostname for the DFM server (string value)
-#netapp_server_hostname=<None>
-<% unless @netapp_params.nil? -%>
-netapp_server_hostname=<%= @netapp_params['netapp_server_hostname'] %>
-<% end -%>
-
-# Port number for the DFM server (integer value)
-#netapp_server_port=8088
-<% unless @netapp_params.nil? -%>
-netapp_server_port=<%= @netapp_params['netapp_server_port'] %>
-<% end -%>
-
-# Transport type for the DFM server (string value)
-#netapp_transport_type=http|https
-<% unless @netapp_params.nil? -%>
-netapp_transport_type=<%= @netapp_params['netapp_transport_type'] %>
-<% end -%>
-
-# Comma separated volumes to be used for provisioning
-#netapp_volume_list=None
-<% unless @netapp_params.nil? -%>
-netapp_volume_list=<%= @netapp_params['netapp_volume_list'] %>
-<% end -%>
-
-# Storage service to use for provisioning (when
-# volume_type=None) (string value)
-#netapp_storage_service=<None>
-<% unless @netapp_params.nil? -%>
-netapp_storage_service=<%= @netapp_params['netapp_storage_service'] %>
-<% end -%>
-
-# Prefix of storage service name to use for provisioning
-# (volume_type name will be appended) (string value)
-#netapp_storage_service_prefix=<None>
-<% unless @netapp_params.nil? -%>
-netapp_storage_service_prefix=<%= @netapp_params['netapp_storage_service_prefix'] %>
-<% end -%>
 
 # Vfiler to use for provisioning (string value)
 #netapp_vfiler=<None>
-<% unless @netapp_params.nil? -%>
 netapp_vfiler=<%= @netapp_params['netapp_vfiler'] %>
+
+# User name for the storage controller (string value)
+#netapp_login=<None>
+netapp_login=<%= @netapp_params['netapp_login'] %>
+
+# Password for the storage controller (string value)
+#netapp_password=<None>
+netapp_password=<%= @netapp_params['netapp_password'] %>
+
+# Cluster vserver to use for provisioning (string value)
+#netapp_vserver=<None>
+netapp_vserver=<%= @netapp_params['vserver'] %>
+
+# Host name for the storage controller (string value)
+#netapp_server_hostname=<None>
+netapp_server_hostname=<%= @netapp_params['netapp_server_hostname'] %>
+
+# Port number for the storage controller (integer value)
+#netapp_server_port=80
+netapp_server_port=<%= @netapp_params['netapp_server_port'] %>
+
+# Threshold available percent to start cache cleaning.
+# (integer value)
+#thres_avl_size_perc_start=20
+
+# Threshold available percent to stop cache cleaning. (integer
+# value)
+#thres_avl_size_perc_stop=60
+
+# Threshold minutes after which cache file can be cleaned.
+# (integer value)
+#expiry_thres_minutes=720
+
+# Volume size multiplier to ensure while creation (floating
+# point value)
+#netapp_size_multiplier=1.2
+
+# Comma separated volumes to be used for provisioning (string
+# value)
+#netapp_volume_list=<None>
+netapp_volume_list=<%= @netapp_params['netapp_volume_list'] %>
+
+# Storage family type. (string value)
+#netapp_storage_family=ontap_cluster
+netapp_storage_family=<%= @netapp_params['storage_family'] %>
+
+# The storage protocol to be used on the data path with the
+# storage system; valid values are iscsi or nfs. (string
+# value)
+netapp_storage_protocol=<%= @netapp_params['storage_protocol'] %>
+
+# Transport type protocol (string value)
+#netapp_transport_type=http
+netapp_transport_type=<%= @netapp_params['netapp_transport_type'] %>
+
 <% end -%>
 
 #
@@ -1211,9 +1211,11 @@ volume_driver=cinder.volume.drivers.eqlx.DellEQLSanISCSIDriver
 <%   end -%>
 <% end -%>
 
+
 <% unless @netapp_params.nil? -%>
-volume_driver=<%= @netapp_params['netapp_driver'] %>
+volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
 <% end -%>
+
 
 <% unless @emc_params.nil? -%>
 volume_driver=cinder.volume.drivers.emc.emc_smis_iscsi.EMCSMISISCSIDriver

--- a/chef/data_bags/crowbar/bc-template-cinder.json
+++ b/chef/data_bags/crowbar/bc-template-cinder.json
@@ -53,14 +53,13 @@
           "eqlx_pool": "default"
         },
         "netapp": {
-          "netapp_driver": "cinder.volume.drivers.netapp.iscsi.NetAppDirect7modeISCSIDriver",
-          "netapp_wsdl_url": "http://192.168.124.11:8088/",
+          "storage_family": "ontap_7mode",
+          "storage_protocol": "iscsi",
+          "vserver": "",
           "netapp_server_hostname": "192.168.124.11",
           "netapp_server_port": 443,
           "netapp_login": "admin",
-          "netapp_password": "admin",
-          "netapp_storage_service": "",
-          "netapp_storage_service_prefix": "crowbar_",
+          "netapp_password": "",
           "netapp_vfiler": "",
           "netapp_transport_type": "https",
           "netapp_volume_list": ""
@@ -104,7 +103,7 @@
   "deployment": {
     "cinder": {
       "crowbar-revision": 0,
-      "schema-revision": 1,
+      "schema-revision": 2,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-cinder.schema
+++ b/chef/data_bags/crowbar/bc-template-cinder.schema
@@ -54,14 +54,13 @@
                   "type": "map",
                   "required": true,
                   "mapping": {
-                    "netapp_driver": { "type": "str", "required": true},
-                    "netapp_wsdl_url": { "type": "str", "required": true },
+                    "storage_family": { "type": "str", "required": true },
+                    "storage_protocol": { "type": "str", "required": true },
+                    "vserver": { "type": "str", "required": true },
                     "netapp_server_hostname": { "type": "str", "required": true },
                     "netapp_server_port": { "type": "int", "required": true },
                     "netapp_login": { "type": "str", "required": true },
                     "netapp_password": { "type": "str", "required": true },
-                    "netapp_storage_service": { "type": "str", "required": true },
-                    "netapp_storage_service_prefix": { "type": "str", "required": true },
                     "netapp_vfiler": { "type": "str", "required": true },
                     "netapp_transport_type": { "type": "str", "required": true },
                     "netapp_volume_list": { "type": "str", "required": true }

--- a/chef/data_bags/crowbar/migrate/cinder/002_netapp_options.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/002_netapp_options.rb
@@ -1,0 +1,37 @@
+def upgrade ta, td, a, d
+  case a["volume"]["netapp"]["netapp_driver"]
+  when "cinder.volume.drivers.netapp.iscsi.NetAppDirect7modeISCSIDriver"
+    a["volume"]["netapp"]["storage_protocol"] = "iscsi"
+    a["volume"]["netapp"]["storage_family"] = "ontap_7mode"
+  when "cinder.volume.drivers.netapp.nfs.NetAppDirect7modeNfsDriver"
+    a["volume"]["netapp"]["storage_protocol"] = "nfs"
+    a["volume"]["netapp"]["storage_family"] = "ontap_7mode"
+  when "cinder.volume.drivers.netapp.iscsi.NetAppDirectCmodeISCSIDriver"
+    a["volume"]["netapp"]["storage_protocol"] = "iscsi"
+    a["volume"]["netapp"]["storage_family"] = "ontap_cluster"
+  when "cinder.volume.drivers.netapp.nfs.NetAppDirectCmodeNfsDriver"
+    a["volume"]["netapp"]["storage_protocol"] = "nfs"
+    a["volume"]["netapp"]["storage_family"] = "ontap_cluster"
+  else
+    a["volume"]["netapp"]["storage_protocol"] = ta["volume"]["netapp"]["storage_protocol"]
+    a["volume"]["netapp"]["storage_family"] = ta["volume"]["netapp"]["storage_family"]
+  end
+  a["volume"]["netapp"]["vserver"] = ta["volume"]["netapp"]["vserver"]
+  a["volume"]["netapp"].delete("netapp_driver")
+  a["volume"]["netapp"].delete("netapp_wsdl_url")
+  a["volume"]["netapp"].delete("netapp_storage_service")
+  a["volume"]["netapp"].delete("netapp_storage_service_prefix")
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  # ideally we'd convert it backwards as well..
+  a["volume"]["netapp"]["netapp_driver"] = ta["volume"]["netapp"]["netapp_driver"]
+  a["volume"]["netapp"]["netapp_wsdl_url"] = ta["volume"]["netapp"]["netapp_wsdl_url"]
+  a["volume"]["netapp"]["netapp_storage_service"] = ta["volume"]["netapp"]["netapp_storage_service"]
+  a["volume"]["netapp"]["netapp_storage_service_prefix"] = ta["volume"]["netapp"]["netapp_storage_service_prefix"]
+  a["volume"]["netapp"].delete('storage_family')
+  a["volume"]["netapp"].delete('storage_protocol')
+  a["volume"]["netapp"].delete('vserver')
+  return a, d
+end

--- a/crowbar_framework/app/helpers/cinder_barclamp_helper.rb
+++ b/crowbar_framework/app/helpers/cinder_barclamp_helper.rb
@@ -58,13 +58,21 @@ module CinderBarclampHelper
     )
   end
 
-  def netapp_drivers_for_cinder(selected)
+  def netapp_storage_family(selected)
     options_for_select(
       [
-        ["7-Mode iSCSI direct driver", "cinder.volume.drivers.netapp.iscsi.NetAppDirect7modeISCSIDriver"],
-        ["7-Mode NFS direct driver", "cinder.volume.drivers.netapp.nfs.NetAppDirect7modeNfsDriver"],
-        ["iSCSI direct driver for clustered Data ONTAP", "cinder.volume.drivers.netapp.iscsi.NetAppDirectCmodeISCSIDriver"],
-        ["NFS direct driver for clustered Data ONTAP", "cinder.volume.drivers.netapp.nfs.NetAppDirectCmodeNfsDriver"]
+        ["Data ONTAP in 7-Mode", "ontap_7mode"],
+        ["Data ONTAP in Clustered Mode", "ontap_cluster"]
+      ],
+      selected.to_s
+    )
+  end
+
+  def netapp_storage_protocol(selected)
+    options_for_select(
+      [
+        ["iSCSI", "iscsi"],
+        ["NFS", "nfs"]
       ],
       selected.to_s
     )
@@ -73,7 +81,7 @@ module CinderBarclampHelper
   def netapp_transports_for_cinder(selected)
     options_for_select(
       [
-        ["HTTP","http"], 
+        ["HTTP","http"],
         ["HTTPS", "https"]
       ],
       selected.to_s

--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -34,13 +34,14 @@
         %legend
           = t('.volume.netapp_parameters')
 
-        = select_field %w(volume netapp netapp_driver), :collection => :netapp_drivers_for_cinder
+        = select_field %w(volume netapp storage_family), :collection => :netapp_storage_family
+        = select_field %w(volume netapp storage_protocol), :collection => :netapp_storage_protocol
         = string_field %w(volume netapp netapp_server_hostname)
+        = string_field %w(volume netapp vserver)
         = select_field %w(volume netapp netapp_transport_type), :collection => :netapp_transports_for_cinder
         = integer_field %w(volume netapp netapp_server_port)
         = string_field %w(volume netapp netapp_login)
         = password_field %w(volume netapp netapp_password)
-        = string_field %w(volume netapp netapp_storage_service)
         = string_field %w(volume netapp netapp_vfiler)
 
     #emc_container

--- a/crowbar_framework/config/locales/cinder.en.yml
+++ b/crowbar_framework/config/locales/cinder.en.yml
@@ -21,14 +21,16 @@ en:
           local_size: Maximum File Size (GB)
           netapp_parameters: NetApp Parameters
           netapp:
-            netapp_driver: NetApp Driver Mode
+            storage_family: Storage Family Type
+            storage_protocol: Storage Protocol
+            vserver: Name of the Virtual Storage Server (Vserver)
             netapp_server_hostname: Server host name
             netapp_transport_type: Transport Type
             netapp_server_port: Server port
             netapp_login: Username for accessing NetApp
             netapp_password: Password for accessing NetApp
-            netapp_storage_service: Storage service to use while provisioning
             netapp_vfiler: The vFiler unit name if using vFiler to host OpenStack volumes
+
           emc_parameters: EMC Parameters
           emc:
             ecom_server_ip: IP address of the ECOM server


### PR DESCRIPTION
The NetApp driver model changed completely with Havana.
Instead of individual drivers, a unified driver needs
to be used now with additional configuration for the
driver mode.
