### PR TITLE
fix NoSuchOptError raised by glance-scheduler when option is nil

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -108,7 +108,9 @@ glance_api_servers=<%= @glance_server_protocol %>://<%= @glance_server_host %>:<
 
 # Allow to perform insecure SSL (https) requests to glance
 # (boolean value)
+<% unless @glance_server_insecure.nil? -%>
 glance_api_insecure=<%= @glance_server_insecure %>
+<% end -%>
 
 # the topic scheduler nodes listen on (string value)
 #scheduler_topic=cinder-scheduler


### PR DESCRIPTION
2014-01-20 12:57:36.127 3866 CRITICAL cinder [-] no such option: glance_api_insecure
2014-01-20 12:57:36.127 3866 TRACE cinder Traceback (most recent call last):
2014-01-20 12:57:36.127 3866 TRACE cinder   File "/usr/bin/cinder-scheduler", line 60, in <module>
2014-01-20 12:57:36.127 3866 TRACE cinder     service.wait()
2014-01-20 12:57:36.127 3866 TRACE cinder   File "/usr/lib64/python2.6/site-packages/cinder/service.py", line 614, in wait
2014-01-20 12:57:36.127 3866 TRACE cinder     flag_get = CONF.get(flag, None)
2014-01-20 12:57:36.127 3866 TRACE cinder   File "/usr/lib64/python2.6/_abcoll.py", line 336, in get
2014-01-20 12:57:36.127 3866 TRACE cinder     return self[key]
2014-01-20 12:57:36.127 3866 TRACE cinder   File "/usr/lib64/python2.6/site-packages/oslo/config/cfg.py", line 1652, in __getitem__
2014-01-20 12:57:36.127 3866 TRACE cinder     return self.**getattr**(key)
2014-01-20 12:57:36.127 3866 TRACE cinder   File "/usr/lib64/python2.6/site-packages/oslo/config/cfg.py", line 1648, in **getattr**
2014-01-20 12:57:36.127 3866 TRACE cinder     raise NoSuchOptError(name)
2014-01-20 12:57:36.127 3866 TRACE cinder NoSuchOptError: no such option: glance_api_insecure
