### PR TITLE
Move lock_path to /var/run

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -591,7 +591,7 @@ sql_connection=<%= @sql_connection %>
 
 # Directory to use for lock files. Default to a temp directory
 # (string value)
-lock_path=/var/lock/cinder
+lock_path=/var/run/cinder
 
 
 #


### PR DESCRIPTION
/var/lock is blacklisted on openSUSE
