### PR TITLE
Restart cinder services when ceph.conf changes

### DIFF
--- a/chef/cookbooks/cinder/definitions/cinder_service.rb
+++ b/chef/cookbooks/cinder/definitions/cinder_service.rb
@@ -30,6 +30,7 @@ define :cinder_service, :virtualenv => nil do
     supports :status => true, :restart => true
     action [:enable, :start]
     subscribes :restart, resources(:template => "/etc/cinder/cinder.conf")
+    subscribes :restart, resources("template[/etc/ceph/ceph.conf]")
   end
 
 end


### PR DESCRIPTION
It is likely that new monitors got added then, and the
daemon needs to reload the configuration at that point
to not hang.

(cherry picked from commit ab1088c246f15708f8c5eab5c1f7840243928985)
