### PR TITLE
Update db password migration script to remove node attributes

### DIFF
--- a/chef/data_bags/crowbar/migrate/cinder/006_generate_db_password.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/006_generate_db_password.rb
@@ -1,9 +1,26 @@
 def upgrade ta, td, a, d
-  if a['db']['password'].nil? || a['db']['password'].empty?
-    # old proposals had passwords created in the cookbook
+  # Old proposals had passwords created in the cookbook, so we need to migrate
+  # them in the proposal and in the role. We use a class variable to set the
+  # same password in the proposal and in the role.
+  unless defined?(@@cinder_db_password)
     service = ServiceObject.new "fake-logger"
-    a['db']['password'] = service.random_password
+    @@cinder_db_password = service.random_password
   end
+
+  Chef::Search::Query.new.search(:node) do |node|
+    unless (node[:cinder][:db][:password] rescue nil).nil?
+      unless node[:cinder][:db][:password].empty?
+        @@cinder_db_password = node[:cinder][:db][:password]
+      end
+      node[:cinder][:db].delete('password')
+      node.save
+    end
+  end
+
+  if a['db']['password'].nil? || a['db']['password'].empty?
+    a['db']['password'] = @@cinder_db_password
+  end
+
   return a, d
 end
 


### PR DESCRIPTION
On update, we want to use the db password from the proposal / role, and
not the one that might have been generated on the node (through the
cookbook). As the password is a "normal" attribute on the node, but a
"default" attribute on the role, the old one from the node is used.
Which means we really need to remove it to get the new one used.

To minimize config changes, we actually import the password from one
node (which should be good enough in most cases as we allow only one
cinder proposal, so only one node should have the password).
