### PR TITLE
Run "cinder-manage db sync" on SUSE when HA is enabled

### DIFF
--- a/chef/cookbooks/cinder/recipes/sql.rb
+++ b/chef/cookbooks/cinder/recipes/sql.rb
@@ -77,10 +77,9 @@ execute "cinder-manage db sync" do
   command "#{venv_prefix}cinder-manage db sync"
   user node[:cinder][:user]
   group node[:cinder][:group]
-  # On SUSE, we only need this when HA is enabled as the init script is doing
-  # this (but that creates races with HA); we only care about it for the
-  # initial sync, though, so we'll do that once, on the founder.
-  only_if { node.platform != "suse" || (!node[:cinder][:db_synced] && node[:cinder][:ha][:enabled] && CrowbarPacemakerHelper.is_cluster_founder?(node)) }
+  # We only do the sync the first time, and only if we're not doing HA or if we
+  # are the founder of the HA cluster (so that it's really only done once).
+  only_if { !node[:cinder][:db_synced] && (!node[:cinder][:ha][:enabled] || CrowbarPacemakerHelper.is_cluster_founder?(node)) }
 end
 
 # We want to keep a note that we've done db_sync, so we don't do it again.


### PR DESCRIPTION
So far, we were not running it because the init script on SUSE does run
it. But with HA enabled, the service starts at the same time on all
nodes, which may result in failures on some nodes because db sync can't
be run multiple times simultaneously. The end result is that the
pacemaker resource was possilby failing on some nodes, which then
required some manual cleanup.
