### PR TITLE
Use the right node to extract the keystone settings

### DIFF
--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -24,8 +24,7 @@ include_recipe "#{@cookbook_name}::sql"
 cinder_path = "/opt/cinder"
 venv_path = node[:cinder][:use_virtualenv] ? "#{cinder_path}/.venv" : nil
 
-keystone = get_instance('roles:keystone-server')
-keystone_settings = KeystoneHelper.keystone_settings(keystone, :cinder)
+keystone_settings = KeystoneHelper.keystone_settings(node, :cinder)
 
 cinder_port = node[:cinder][:api][:bind_port]
 cinder_protocol = node[:cinder][:api][:protocol]


### PR DESCRIPTION
The keystone_helper needs to be called with the current node to extract the
correct keystone settings. Using the node with the keystone-server role is
wrong and breaks when keystone and cinder are deployed on different nodes.
