### PR TITLE
ensure that api-paste.ini does not contain the auth_token

### DIFF
--- a/chef/cookbooks/cinder/files/default/api-paste.ini
+++ b/chef/cookbooks/cinder/files/default/api-paste.ini
@@ -1,0 +1,55 @@
+#############
+# OpenStack #
+#############
+
+[composite:osapi_volume]
+use = call:cinder.api:root_app_factory
+/: apiversions
+/v1: openstack_volume_api_v1
+/v2: openstack_volume_api_v2
+
+[composite:openstack_volume_api_v1]
+use = call:cinder.api.middleware.auth:pipeline_factory
+noauth = request_id faultwrap sizelimit noauth apiv1
+keystone = request_id faultwrap sizelimit authtoken keystonecontext apiv1
+keystone_nolimit = request_id faultwrap sizelimit authtoken keystonecontext apiv1
+
+[composite:openstack_volume_api_v2]
+use = call:cinder.api.middleware.auth:pipeline_factory
+noauth = request_id faultwrap sizelimit noauth apiv2
+keystone = request_id faultwrap sizelimit authtoken keystonecontext apiv2
+keystone_nolimit = request_id faultwrap sizelimit authtoken keystonecontext apiv2
+
+[filter:request_id]
+paste.filter_factory = cinder.openstack.common.middleware.request_id:RequestIdMiddleware.factory
+
+[filter:faultwrap]
+paste.filter_factory = cinder.api.middleware.fault:FaultWrapper.factory
+
+[filter:noauth]
+paste.filter_factory = cinder.api.middleware.auth:NoAuthMiddleware.factory
+
+[filter:sizelimit]
+paste.filter_factory = cinder.api.middleware.sizelimit:RequestBodySizeLimiter.factory
+
+[app:apiv1]
+paste.app_factory = cinder.api.v1.router:APIRouter.factory
+
+[app:apiv2]
+paste.app_factory = cinder.api.v2.router:APIRouter.factory
+
+[pipeline:apiversions]
+pipeline = faultwrap osvolumeversionapp
+
+[app:osvolumeversionapp]
+paste.app_factory = cinder.api.versions:Versions.factory
+
+##########
+# Shared #
+##########
+
+[filter:keystonecontext]
+paste.filter_factory = cinder.api.middleware.auth:CinderKeystoneContext.factory
+
+[filter:authtoken]
+paste.filter_factory = keystoneclient.middleware.auth_token:filter_factory

--- a/chef/cookbooks/cinder/recipes/api.rb
+++ b/chef/cookbooks/cinder/recipes/api.rb
@@ -97,3 +97,19 @@ crowbar_pacemaker_sync_mark "create-cinder_register"
 cinder_service "api" do
   use_pacemaker_provider ha_enabled
 end
+
+# XXX this is no different from the file provided in the package, but
+# since we used to have a configured template here, we need to make sure
+# that it gets overwritten specifically since it used to contain
+# auth_token configuration options which conflict with the ones in
+# cinder.conf and the packages won't overwrite a modified file.
+# This block can be removed when either cinder does not read auth_token
+# configuration from api-paste.ini or we are sure that the target
+# machine no longer has an api-paste.ini file with the auth_token settings
+cookbook_file "api-paste.ini" do
+  path "/etc/cinder/api-paste.ini"
+  owner "root"
+  group node[:cinder][:group]
+  mode "0640"
+  action :create
+end


### PR DESCRIPTION
Since commit 70798fb2624 removed the api-paste.ini template from chef, systems
which already had it installed by chef would keep the old version because it
was modified outside of rpm. But these files contained the auth_token
middleware configuration which would conflict with the one from cinder.conf.

This commit fixes that problem by making sure to overwrite api-paste.ini with
a vanilla file from the git repository (current stable/icehouse)
