### PR TITLE
Switch to thin LVM backend by default

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -1288,7 +1288,7 @@ volume_group=<%= node[:cinder][:volume][:local][:volume_name] %>
 
 # Type of LVM volumes to deploy; (default or thin) (string
 # value)
-#lvm_type=default
+lvm_type=thin
 
 
 #


### PR DESCRIPTION
This provides first of all significant more performance
for volumes about snapshots (thick snapshots turn every write
on the volume to a sync+flush for the snapshot), and saves disk
space at the same time. Furthermore it avoids hang issues
with the SLE11 lvm (which does not have lvmetad enabled and hence
rescans the lvs on every command).
