### PR TITLE
Synchronize cinder.conf template with Icehouse

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -1,8 +1,202 @@
-####################
-# cinder.conf sample #
-####################
-
 [DEFAULT]
+
+#
+# Options defined in oslo.messaging
+#
+
+# Use durable queues in amqp. (boolean value)
+# Deprecated group/name - [DEFAULT]/rabbit_durable_queues
+#amqp_durable_queues=false
+
+# Auto-delete queues in amqp. (boolean value)
+#amqp_auto_delete=false
+
+# Size of RPC connection pool. (integer value)
+#rpc_conn_pool_size=30
+
+# Modules of exceptions that are permitted to be recreated
+# upon receiving exception data from an rpc call. (list value)
+#allowed_rpc_exception_modules=oslo.messaging.exceptions,nova.exception,cinder.exception,exceptions
+
+# Qpid broker hostname. (string value)
+#qpid_hostname=localhost
+
+# Qpid broker port. (integer value)
+#qpid_port=5672
+
+# Qpid HA cluster host:port pairs. (list value)
+#qpid_hosts=$qpid_hostname:$qpid_port
+
+# Username for Qpid connection. (string value)
+#qpid_username=
+
+# Password for Qpid connection. (string value)
+#qpid_password=
+
+# Space separated list of SASL mechanisms to use for auth.
+# (string value)
+#qpid_sasl_mechanisms=
+
+# Seconds between connection keepalive heartbeats. (integer
+# value)
+#qpid_heartbeat=60
+
+# Transport to use, either 'tcp' or 'ssl'. (string value)
+#qpid_protocol=tcp
+
+# Whether to disable the Nagle algorithm. (boolean value)
+#qpid_tcp_nodelay=true
+
+# The qpid topology version to use.  Version 1 is what was
+# originally used by impl_qpid.  Version 2 includes some
+# backwards-incompatible changes that allow broker federation
+# to work.  Users should update to version 2 when they are
+# able to take everything down, as it requires a clean break.
+# (integer value)
+#qpid_topology_version=1
+
+# SSL version to use (valid only if SSL enabled). valid values
+# are TLSv1, SSLv23 and SSLv3. SSLv2 may be available on some
+# distributions. (string value)
+#kombu_ssl_version=
+
+# SSL key file (valid only if SSL enabled). (string value)
+#kombu_ssl_keyfile=
+
+# SSL cert file (valid only if SSL enabled). (string value)
+#kombu_ssl_certfile=
+
+# SSL certification authority file (valid only if SSL
+# enabled). (string value)
+#kombu_ssl_ca_certs=
+
+# How long to wait before reconnecting in response to an AMQP
+# consumer cancel notification. (floating point value)
+#kombu_reconnect_delay=1.0
+
+# The RabbitMQ broker address where a single node is used.
+# (string value)
+rabbit_host=<%= @rabbit_settings[:address] %>
+
+# The RabbitMQ broker port where a single node is used.
+# (integer value)
+#rabbit_port=5672
+<% unless @rabbit_settings[:port].nil? -%>
+rabbit_port=<%= @rabbit_settings[:port] %>
+<% end -%>
+
+# RabbitMQ HA cluster host:port pairs. (list value)
+#rabbit_hosts=$rabbit_host:$rabbit_port
+
+# Connect over SSL for RabbitMQ. (boolean value)
+#rabbit_use_ssl=false
+
+# The RabbitMQ userid. (string value)
+rabbit_userid=<%= @rabbit_settings[:user] %>
+
+# The RabbitMQ password. (string value)
+rabbit_password=<%= @rabbit_settings[:password] %>
+
+# the RabbitMQ login method (string value)
+#rabbit_login_method=AMQPLAIN
+
+# The RabbitMQ virtual host. (string value)
+rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
+
+# How frequently to retry connecting with RabbitMQ. (integer
+# value)
+#rabbit_retry_interval=1
+
+# How long to backoff for between retries when connecting to
+# RabbitMQ. (integer value)
+#rabbit_retry_backoff=2
+
+# Maximum number of RabbitMQ connection retries. Default is 0
+# (infinite retry count). (integer value)
+#rabbit_max_retries=0
+
+# Use HA queues in RabbitMQ (x-ha-policy: all). If you change
+# this option, you must wipe the RabbitMQ database. (boolean
+# value)
+#rabbit_ha_queues=false
+
+# If passed, use a fake RabbitMQ provider. (boolean value)
+#fake_rabbit=false
+
+# ZeroMQ bind address. Should be a wildcard (*), an ethernet
+# interface, or IP. The "host" option should point or resolve
+# to this address. (string value)
+#rpc_zmq_bind_address=*
+
+# MatchMaker driver. (string value)
+#rpc_zmq_matchmaker=oslo.messaging._drivers.matchmaker.MatchMakerLocalhost
+
+# ZeroMQ receiver listening port. (integer value)
+#rpc_zmq_port=9501
+
+# Number of ZeroMQ contexts, defaults to 1. (integer value)
+#rpc_zmq_contexts=1
+
+# Maximum number of ingress messages to locally buffer per
+# topic. Default is unlimited. (integer value)
+#rpc_zmq_topic_backlog=<None>
+
+# Directory for holding IPC sockets. (string value)
+#rpc_zmq_ipc_dir=/var/run/openstack
+
+# Name of this node. Must be a valid hostname, FQDN, or IP
+# address. Must match "host" option, if running Nova. (string
+# value)
+#rpc_zmq_host=cinder
+
+# Seconds to wait before a cast expires (TTL). Only supported
+# by impl_zmq. (integer value)
+#rpc_cast_timeout=30
+
+# Heartbeat frequency. (integer value)
+#matchmaker_heartbeat_freq=300
+
+# Heartbeat time-to-live. (integer value)
+#matchmaker_heartbeat_ttl=600
+
+# Host to locate redis. (string value)
+#host=127.0.0.1
+
+# Use this port to connect to redis host. (integer value)
+#port=6379
+
+# Password for Redis server (optional). (string value)
+#password=<None>
+
+# Size of RPC greenthread pool. (integer value)
+#rpc_thread_pool_size=64
+
+# Driver or drivers to handle sending notifications. (multi
+# valued)
+#notification_driver=
+
+# AMQP topic used for OpenStack notifications. (list value)
+# Deprecated group/name - [rpc_notifier2]/topics
+#notification_topics=notifications
+
+# Seconds to wait for a response from a call. (integer value)
+#rpc_response_timeout=60
+
+# A URL representing the messaging driver to use and its full
+# configuration. If not set, we fall back to the rpc_backend
+# option and driver specific configuration. (string value)
+#transport_url=<None>
+
+# The messaging driver to use, defaults to rabbit. Other
+# drivers include qpid and zmq. (string value)
+# Note: explicitely set this because of RHEL (where qpid is used by default)
+rpc_backend=rabbit
+
+# The default exchange under which topics are scoped. May be
+# overridden by an exchange name specified in the
+# transport_url option. (string value)
+control_exchange=cinder
+
 
 #
 # Options defined in cinder.exception
@@ -80,6 +274,10 @@ osapi_volume_listen=<%= @bind_host %>
 # port for os volume api to listen (integer value)
 osapi_volume_listen_port=<%= @bind_port %>
 
+# Number of workers for OpenStack Volume API service (integer
+# value)
+#osapi_volume_workers=<None>
+
 
 #
 # Options defined in cinder.test
@@ -88,17 +286,16 @@ osapi_volume_listen_port=<%= @bind_port %>
 # File name of clean sqlite db (string value)
 #sqlite_clean_db=clean.sqlite
 
-# should we use everything for testing (boolean value)
-#fake_tests=true
-
 
 #
 # Options defined in cinder.wsgi
 #
 
-# Number of backlog requests to configure the socket with
-# (integer value)
-#backlog=4096
+# Maximum line size of message headers to be accepted.
+# max_header_line may need to be increased when using large
+# tokens (typically those generated by the Keystone v3 API
+# with big service catalogs). (integer value)
+#max_header_line=16384
 
 # Sets the value of TCP_KEEPIDLE in seconds for each server
 # socket. Not supported on OS X. (integer value)
@@ -127,6 +324,7 @@ ssl_key_file=<%= node[:cinder][:ssl][:keyfile] if node[:cinder][:api][:protocol]
 
 # Base URL that will be presented to users in links to the
 # OpenStack Volume API (string value)
+# Deprecated group/name - [DEFAULT]/osapi_compute_link_prefix
 #osapi_volume_base_URL=<None>
 
 
@@ -148,32 +346,45 @@ ssl_key_file=<%= node[:cinder][:ssl][:keyfile] if node[:cinder][:api][:protocol]
 
 
 #
+# Options defined in cinder.backup.driver
+#
+
+# Backup metadata version to be used when backing up volume
+# metadata. If this number is bumped, make sure the service
+# doing the restore supports the new version. (integer value)
+#backup_metadata_version=1
+
+
+#
 # Options defined in cinder.backup.drivers.ceph
 #
 
-# Ceph config file to use. (string value)
+# Ceph configuration file to use. (string value)
 #backup_ceph_conf=/etc/ceph/ceph.conf
 
-# the Ceph user to connect with (string value)
+# The Ceph user to connect with. Default here is to use the
+# same user as for Cinder volumes. If not using cephx this
+# should be set to None. (string value)
 #backup_ceph_user=cinder
 
-# the chunk size in bytes that a backup will be broken into
-# before transfer to backup store (integer value)
+# The chunk size, in bytes, that a backup is broken into
+# before transfer to the Ceph object store. (integer value)
 #backup_ceph_chunk_size=134217728
 
-# the Ceph pool to backup to (string value)
+# The Ceph pool where volume backups are stored. (string
+# value)
 #backup_ceph_pool=backups
 
-# RBD stripe unit to use when creating a backup image (integer
-# value)
+# RBD stripe unit to use when creating a backup image.
+# (integer value)
 #backup_ceph_stripe_unit=0
 
-# RBD stripe count to use when creating a backup image
+# RBD stripe count to use when creating a backup image.
 # (integer value)
 #backup_ceph_stripe_count=0
 
-# If True, always discard excess bytes when restoring volumes.
-# (boolean value)
+# If True, always discard excess bytes when restoring volumes
+# i.e. pad with zeroes. (boolean value)
 #restore_discard_excess_bytes=true
 
 
@@ -231,6 +442,7 @@ ssl_key_file=<%= node[:cinder][:ssl][:keyfile] if node[:cinder][:api][:protocol]
 #
 
 # Driver to use for backups. (string value)
+# Deprecated group/name - [DEFAULT]/backup_service
 #backup_driver=cinder.backup.drivers.swift
 
 
@@ -238,23 +450,13 @@ ssl_key_file=<%= node[:cinder][:ssl][:keyfile] if node[:cinder][:api][:protocol]
 # Options defined in cinder.common.config
 #
 
-# Virtualization api connection type : libvirt, xenapi, or
-# fake (string value)
-connection_type=libvirt
-
 # File name for the paste.deploy config for cinder-api (string
 # value)
 #api_paste_config=api-paste.ini
 
-# Directory where the cinder python module is installed
-# (string value)
-#pybasedir=/usr/lib/python/site-packages
-
-# Directory where cinder binaries are installed (string value)
-#bindir=$pybasedir/bin
-
 # Top-level directory for maintaining cinder's state (string
 # value)
+# Deprecated group/name - [DEFAULT]/pybasedir
 state_path=/var/lib/cinder
 
 # ip address of this host (string value)
@@ -305,10 +507,10 @@ glance_api_insecure=<%= @glance_server_insecure %>
 # the topic volume backup nodes listen on (string value)
 #backup_topic=cinder-backup
 
-# Deploy v1 of the Cinder API.  (boolean value)
+# Deploy v1 of the Cinder API. (boolean value)
 #enable_v1_api=true
 
-# Deploy v2 of the Cinder API.  (boolean value)
+# Deploy v2 of the Cinder API. (boolean value)
 enable_v2_api=<%= @enable_v2_api ? 'true' : 'false' %>
 
 # whether to rate limit the api (boolean value)
@@ -349,19 +551,12 @@ storage_availability_zone=<%= @availability_zone %>
 # availability_zone for new volumes. (string value)
 #default_availability_zone=<None>
 
-# Memcached servers or None for in process cache. (list value)
-#memcached_servers=<None>
-
 # default volume type to use (string value)
 #default_volume_type=<None>
 
 # time period to generate volume usages for.  Time period must
 # be hour, day, month or year (string value)
 #volume_usage_audit_period=month
-
-# Deprecated: command to use for running commands as root
-# (string value)
-#root_helper=sudo
 
 # Path to the rootwrap configuration file to use for running
 # commands as root (string value)
@@ -392,7 +587,7 @@ auth_strategy=keystone
 # A list of backend names to use. These backend names should
 # be backed by a unique [CONFIG] group with its options (list
 # value)
-#
+#enabled_backends=<None>
 <% if @use_multi_backend -%>
 enabled_backends=<%= @volumes.each_with_index.collect { |backend,idx|
     "backend-#{backend['backend_driver']}-#{idx}"
@@ -431,8 +626,8 @@ nova_catalog_info=compute:nova:internalURL
 nova_catalog_admin_info=compute:nova:adminURL
 
 # Override service catalog lookup with template for nova
-# endpoint e.g. http://localhost:8774/v2/%(tenant_id)s (string
-# value)
+# endpoint e.g. http://localhost:8774/v2/%(project_id)s
+# (string value)
 #nova_endpoint_template=<None>
 
 # Same as nova_endpoint_template, but for admin endpoint.
@@ -442,7 +637,7 @@ nova_catalog_admin_info=compute:nova:adminURL
 # region name of this node (string value)
 #os_region_name=<None>
 
-# Location of ca certicates file to use for nova client
+# Location of ca certificates file to use for nova client
 # requests. (string value)
 #nova_ca_certificates_file=<None>
 
@@ -503,74 +698,8 @@ nova_api_insecure=<%= @nova_api_insecure %>
 
 
 #
-# Options defined in cinder.keymgr
-#
-
-# The full class name of the key manager API class (string
-# value)
-#api_class=cinder.keymgr.conf_key_mgr.ConfKeyManager
-
-
-#
-# Options defined in cinder.keymgr.conf_key_mgr
-#
-
-# Fixed key returned by key manager, specified in hex (string
-# value)
-#fixed_key=<None>
-
-
-#
-# Options defined in cinder.openstack.common.db.api
-#
-
-# The backend to use for db (string value)
-#backend=sqlalchemy
-
-# Enable the experimental use of thread pooling for all DB API
-# calls (boolean value)
-#use_tpool=false
-
-
-#
 # Options defined in cinder.openstack.common.db.sqlalchemy.session
 #
-
-# The SQLAlchemy connection string used to connect to the
-# database (string value)
-sql_connection=<%= @sql_connection %>
-
-# timeout before idle sql connections are reaped (integer
-# value)
-#idle_timeout=3600
-
-# Minimum number of SQL connections to keep open in a pool
-# (integer value)
-#min_pool_size=1
-
-# Maximum number of SQL connections to keep open in a pool
-# (integer value)
-#max_pool_size=5
-
-# maximum db connection retries during startup. (setting -1
-# implies an infinite retry count) (integer value)
-#max_retries=10
-
-# interval between retries of opening a sql connection
-# (integer value)
-#retry_interval=10
-
-# If set, use this value for max_overflow with sqlalchemy
-# (integer value)
-#max_overflow=<None>
-
-# Verbosity of SQL debugging information. 0=None,
-# 100=Everything (integer value)
-#connection_debug=0
-
-# Add python stack traces to SQL as comment strings (boolean
-# value)
-#connection_trace=false
 
 # the filename to use with sqlite (string value)
 #sqlite_db=cinder.sqlite
@@ -583,7 +712,14 @@ sql_connection=<%= @sql_connection %>
 # Options defined in cinder.openstack.common.eventlet_backdoor
 #
 
-# port for eventlet backdoor to listen (integer value)
+# Enable eventlet backdoor.  Acceptable values are 0, <port>,
+# and <start>:<end>, where 0 results in listening on a random
+# tcp port number; <port> results in listening on the
+# specified port number (and not enabling backdoor if that
+# port is in use); and <start>:<end> results in listening on
+# the smallest unused port number within the specified range
+# of port numbers.  The chosen port is displayed in the
+# service's log file. (string value)
 #backdoor_port=<None>
 
 
@@ -614,29 +750,29 @@ verbose=<%= node[:cinder][:verbose] %>
 # Log output to standard error (boolean value)
 #use_stderr=true
 
-# format string to use for log messages with context (string
+# Format string to use for log messages with context (string
 # value)
-#logging_context_format_string=%(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user)s %(tenant)s] %(instance)s%(message)s
+#logging_context_format_string=%(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [%(request_id)s %(user_identity)s] %(instance)s%(message)s
 
-# format string to use for log messages without context
+# Format string to use for log messages without context
 # (string value)
 #logging_default_format_string=%(asctime)s.%(msecs)03d %(process)d %(levelname)s %(name)s [-] %(instance)s%(message)s
 
-# data to append to log format when level is DEBUG (string
+# Data to append to log format when level is DEBUG (string
 # value)
 #logging_debug_format_suffix=%(funcName)s %(pathname)s:%(lineno)d
 
-# prefix each line of exception output with this format
+# Prefix each line of exception output with this format
 # (string value)
 #logging_exception_prefix=%(asctime)s.%(msecs)03d %(process)d TRACE %(name)s %(instance)s
 
-# list of logger=LEVEL pairs (list value)
-#default_log_levels=amqplib=WARN,sqlalchemy=WARN,boto=WARN,suds=INFO,keystone=INFO,eventlet.wsgi.server=WARN
+# List of logger=LEVEL pairs (list value)
+#default_log_levels=amqp=WARN,amqplib=WARN,boto=WARN,qpid=WARN,sqlalchemy=WARN,suds=INFO,oslo.messaging=INFO,iso8601=WARN,requests.packages.urllib3.connectionpool=WARN
 
-# publish error events (boolean value)
+# Publish error events (boolean value)
 #publish_errors=false
 
-# make deprecations fatal (boolean value)
+# Make deprecations fatal (boolean value)
 #fatal_deprecations=false
 
 # If an instance is passed with the log message, format it
@@ -647,16 +783,17 @@ verbose=<%= node[:cinder][:verbose] %>
 # it like this (string value)
 #instance_uuid_format="[instance: %(uuid)s] "
 
-# If this option is specified, the logging configuration file
-# specified is used and overrides any other logging options
-# specified. Please see the Python logging module
-# documentation for details on logging configuration files.
-# (string value)
-#log_config=<None>
+# The name of logging configuration file. It does not disable
+# existing loggers, but just appends specified logging
+# configuration to any other existing logging options. Please
+# see the Python logging module documentation for details on
+# logging configuration files. (string value)
+# Deprecated group/name - [DEFAULT]/log_config
+#log_config_append=<None>
 
-# A logging.Formatter log message format string which may use
-# any of the available logging.LogRecord attributes. This
-# option is deprecated.  Please use
+# DEPRECATED. A logging.Formatter log message format string
+# which may use any of the available logging.LogRecord
+# attributes. This option is deprecated.  Please use
 # logging_context_format_string and
 # logging_default_format_string instead. (string value)
 #log_format=<None>
@@ -667,16 +804,27 @@ verbose=<%= node[:cinder][:verbose] %>
 
 # (Optional) Name of log file to output to. If no default is
 # set, logging will go to stdout. (string value)
+# Deprecated group/name - [DEFAULT]/logfile
 #log_file=<None>
 
 # (Optional) The base directory used for relative --log-file
 # paths (string value)
+# Deprecated group/name - [DEFAULT]/logdir
+#log_dir=<None>
 log_dir=/var/log/cinder
 
-# Use syslog for logging. (boolean value)
+# Use syslog for logging. Existing syslog format is DEPRECATED
+# during I, and then will be changed in J to honor RFC5424
+# (boolean value)
 use_syslog=<%= node[:cinder][:use_syslog] ? "True" : "False" %>
 
-# syslog facility to receive log lines (string value)
+# (Optional) Use syslog rfc5424 format for logging. If
+# enabled, will add APP-NAME (RFC5424) before the MSG part of
+# the syslog message.  The old format without APP-NAME is
+# deprecated in I, and will be removed in J. (boolean value)
+#use_syslog_rfc_format=false
+
+# Syslog facility to receive log lines (string value)
 #syslog_log_facility=LOG_USER
 
 
@@ -688,30 +836,6 @@ use_syslog=<%= node[:cinder][:use_syslog] ? "True" : "False" %>
 # valued)
 notification_driver=cinder.openstack.common.notifier.rpc_notifier
 
-# Default notification level for outgoing notifications
-# (string value)
-#default_notification_level=INFO
-
-# Default publisher_id for outgoing notifications (string
-# value)
-#default_publisher_id=<None>
-
-
-#
-# Options defined in cinder.openstack.common.notifier.rpc_notifier
-#
-
-# AMQP topic used for OpenStack notifications (list value)
-#notification_topics=notifications
-
-
-#
-# Options defined in cinder.openstack.common.notifier.rpc_notifier2
-#
-
-# AMQP topic(s) used for OpenStack notifications (list value)
-#topics=notifications
-
 
 #
 # Options defined in cinder.openstack.common.periodic_task
@@ -720,221 +844,6 @@ notification_driver=cinder.openstack.common.notifier.rpc_notifier
 # Some periodic tasks can be run in a separate process. Should
 # we run them here? (boolean value)
 #run_external_periodic_tasks=true
-
-
-#
-# Options defined in cinder.openstack.common.rpc
-#
-
-# The messaging module to use, defaults to kombu. (string
-# value)
-# Note: explicitely set this because of RHEL (where qpid is used by default)
-rpc_backend=cinder.openstack.common.rpc.impl_kombu
-
-# Size of RPC thread pool (integer value)
-#rpc_thread_pool_size=64
-
-# Size of RPC connection pool (integer value)
-#rpc_conn_pool_size=30
-
-# Seconds to wait for a response from call or multicall
-# (integer value)
-#rpc_response_timeout=60
-
-# Seconds to wait before a cast expires (TTL). Only supported
-# by impl_zmq. (integer value)
-#rpc_cast_timeout=30
-
-# Modules of exceptions that are permitted to be recreatedupon
-# receiving exception data from an rpc call. (list value)
-#allowed_rpc_exception_modules=nova.exception,cinder.exception,exceptions
-
-# If passed, use a fake RabbitMQ provider (boolean value)
-#fake_rabbit=false
-
-# AMQP exchange to connect to if using RabbitMQ or Qpid
-# (string value)
-control_exchange=cinder
-
-
-#
-# Options defined in cinder.openstack.common.rpc.amqp
-#
-
-# Enable a fast single reply queue if using AMQP based RPC
-# like RabbitMQ or Qpid. (boolean value)
-#amqp_rpc_single_reply_queue=false
-
-# Use durable queues in amqp. (boolean value)
-#amqp_durable_queues=false
-
-# Auto-delete queues in amqp. (boolean value)
-#amqp_auto_delete=false
-
-
-#
-# Options defined in cinder.openstack.common.rpc.impl_kombu
-#
-
-# SSL version to use (valid only if SSL enabled) (string
-# value)
-#kombu_ssl_version=
-
-# SSL key file (valid only if SSL enabled) (string value)
-#kombu_ssl_keyfile=
-
-# SSL cert file (valid only if SSL enabled) (string value)
-#kombu_ssl_certfile=
-
-# SSL certification authority file (valid only if SSL enabled)
-# (string value)
-#kombu_ssl_ca_certs=
-
-<% if @rabbit_settings -%>
-# The RabbitMQ broker address where a single node is used
-# (string value)
-rabbit_host=<%= @rabbit_settings[:address] %>
-
-# The RabbitMQ broker port where a single node is used
-# (integer value)
-<% unless @rabbit_settings[:port].nil? -%>
-rabbit_port=<%= @rabbit_settings[:port] %>
-<% end -%>
-
-# RabbitMQ HA cluster host:port pairs (list value)
-#rabbit_hosts=$rabbit_host:$rabbit_port
-
-# connect over SSL for RabbitMQ (boolean value)
-#rabbit_use_ssl=false
-
-# the RabbitMQ userid (string value)
-rabbit_userid=<%= @rabbit_settings[:user] %>
-
-# the RabbitMQ password (string value)
-rabbit_password=<%= @rabbit_settings[:password] %>
-
-# the RabbitMQ virtual host (string value)
-rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
-
-# how frequently to retry connecting with RabbitMQ (integer
-# value)
-#rabbit_retry_interval=1
-
-# how long to backoff for between retries when connecting to
-# RabbitMQ (integer value)
-#rabbit_retry_backoff=2
-
-# maximum retries with trying to connect to RabbitMQ (the
-# default of 0 implies an infinite retry count) (integer
-# value)
-#rabbit_max_retries=0
-
-# use H/A queues in RabbitMQ (x-ha-policy: all).You need to
-# wipe RabbitMQ database when changing this option. (boolean
-# value)
-#rabbit_ha_queues=false
-<% end -%>
-
-
-#
-# Options defined in cinder.openstack.common.rpc.impl_qpid
-#
-
-# Qpid broker hostname (string value)
-#qpid_hostname=localhost
-
-# Qpid broker port (integer value)
-#qpid_port=5672
-
-# Qpid HA cluster host:port pairs (list value)
-#qpid_hosts=$qpid_hostname:$qpid_port
-
-# Username for qpid connection (string value)
-#qpid_username=
-
-# Password for qpid connection (string value)
-#qpid_password=
-
-# Space separated list of SASL mechanisms to use for auth
-# (string value)
-#qpid_sasl_mechanisms=
-
-# Seconds between connection keepalive heartbeats (integer
-# value)
-#qpid_heartbeat=60
-
-# Transport to use, either 'tcp' or 'ssl' (string value)
-#qpid_protocol=tcp
-
-# Disable Nagle algorithm (boolean value)
-#qpid_tcp_nodelay=true
-
-# The qpid topology version to use.  Version 1 is what was
-# originally used by impl_qpid.  Version 2 includes some
-# backwards-incompatible changes that allow broker federation
-# to work.  Users should update to version 2 when they are
-# able to take everything down, as it requires a clean break.
-# (integer value)
-#qpid_topology_version=1
-
-
-#
-# Options defined in cinder.openstack.common.rpc.impl_zmq
-#
-
-# ZeroMQ bind address. Should be a wildcard (*), an ethernet
-# interface, or IP. The "host" option should point or resolve
-# to this address. (string value)
-#rpc_zmq_bind_address=*
-
-# MatchMaker driver (string value)
-#rpc_zmq_matchmaker=cinder.openstack.common.rpc.matchmaker.MatchMakerLocalhost
-
-# ZeroMQ receiver listening port (integer value)
-#rpc_zmq_port=9501
-
-# Number of ZeroMQ contexts, defaults to 1 (integer value)
-#rpc_zmq_contexts=1
-
-# Maximum number of ingress messages to locally buffer per
-# topic. Default is unlimited. (integer value)
-#rpc_zmq_topic_backlog=<None>
-
-# Directory for holding IPC sockets (string value)
-#rpc_zmq_ipc_dir=/var/run/openstack
-
-# Name of this node. Must be a valid hostname, FQDN, or IP
-# address. Must match "host" option, if running Nova. (string
-# value)
-#rpc_zmq_host=cinder
-
-
-#
-# Options defined in cinder.openstack.common.rpc.matchmaker
-#
-
-# Matchmaker ring file (JSON) (string value)
-#matchmaker_ringfile=/etc/nova/matchmaker_ring.json
-
-# Heartbeat frequency (integer value)
-#matchmaker_heartbeat_freq=300
-
-# Heartbeat time-to-live. (integer value)
-#matchmaker_heartbeat_ttl=600
-
-
-#
-# Options defined in cinder.openstack.common.rpc.matchmaker_redis
-#
-
-# Host to locate redis (string value)
-#host=127.0.0.1
-
-# Use this port to connect to redis host. (integer value)
-#port=6379
-
-# Password for Redis server. (optional) (string value)
-#password=<None>
 
 
 #
@@ -983,8 +892,11 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 # Options defined in cinder.scheduler.simple
 #
 
-# maximum number of volume gigabytes to allow per host
-# (integer value)
+# This configure option has been deprecated along with the
+# SimpleScheduler.  New scheduler is able to gather capacity
+# information for each host, thus setting the maximum number
+# of volume gigabytes for host is no longer needed.  It's safe
+# to remove this configure from cinder.conf. (integer value)
 #max_gigabytes=10000
 
 
@@ -995,6 +907,10 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 # Multiplier used for weighing volume capacity. Negative
 # numbers mean to stack vs spread. (floating point value)
 #capacity_weight_multiplier=1.0
+
+# Multiplier used for weighing volume capacity. Negative
+# numbers mean to stack vs spread. (floating point value)
+#allocated_capacity_weight_multiplier=-1.0
 
 
 #
@@ -1021,67 +937,26 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 # source volume (boolean value)
 #cloned_volume_same_az=true
 
-#############################################################################
-#############################################################################
+
 #############################################################################
 #############################################################################
 ## Cinder backends
 #############################################################################
-
+#############################################################################
 <%
   @volumes.each_with_index do |volume, volid|
 
     backend_id = "backend-#{volume['backend_driver']}-#{volid}"
-%>
-#############################################################################
+-%>
+
 
 <% if @use_multi_backend -%>
 [<%= backend_id %>]
-
-# The backend name for a given driver implementation (string
-# value)
-volume_backend_name=<%= volume['backend_name'] %>
 <% end -%>
 
 #
 # Options defined in cinder.volume.driver
 #
-
-# number of times to attempt to run flakey shell commands
-# (integer value)
-#num_shell_tries=3
-
-# The percentage of backend capacity is reserved (integer
-# value)
-#reserved_percentage=0
-
-# The maximum number of iscsi target ids per host (integer
-# value)
-#iscsi_num_targets=100
-
-# prefix for iscsi volumes (string value)
-<% if volume['backend_driver'] == 'emc' -%>
-    <% case volume["emc"]["emc_storage_type"].downcase %>
-    <% when "vnx" %>
-iscsi_target_prefix = iqn.2001-07.com.vnx
-    <% when "vmax" %>
-iscsi_target_prefix = iqn.1992-04.com.em
-    <% end %>
-<% end -%>
-
-# The IP address that the iSCSI daemon is listening on (string
-# value)
-<% if volume['backend_driver'] == 'emc' -%>
-iscsi_ip_address = <%= volume["emc"]["emc_ecom_server_ip"] %>
-<% end -%>
-
-# The port that the iSCSI daemon is listening on (integer
-# value)
-#iscsi_port=3260
-
-# The maximum number of times to rescan targets to find volume
-# (integer value)
-#num_volume_device_scan_tries=3
 
 # The maximum number of times to rescan iSER targetto find
 # volume (integer value)
@@ -1105,6 +980,50 @@ iscsi_ip_address = <%= volume["emc"]["emc_ecom_server_ip"] %>
 # iser target user-land tool to use (string value)
 #iser_helper=tgtadm
 
+# number of times to attempt to run flakey shell commands
+# (integer value)
+#num_shell_tries=3
+
+# The percentage of backend capacity is reserved (integer
+# value)
+#reserved_percentage=0
+
+# The maximum number of iscsi target ids per host (integer
+# value)
+#iscsi_num_targets=100
+
+# prefix for iscsi volumes (string value)
+<% if volume['backend_driver'] == 'emc' -%>
+    <% case volume["emc"]["emc_storage_type"].downcase -%>
+    <% when "vnx" -%>
+iscsi_target_prefix = iqn.2001-07.com.vnx
+    <% when "vmax" -%>
+iscsi_target_prefix = iqn.1992-04.com.em
+    <% end -%>
+<% end -%>
+
+# The IP address that the iSCSI daemon is listening on (string
+# value)
+<% if volume['backend_driver'] == 'emc' -%>
+iscsi_ip_address = <%= volume["emc"]["emc_ecom_server_ip"] %>
+<% end -%>
+
+# The port that the iSCSI daemon is listening on (integer
+# value)
+#iscsi_port=3260
+
+# The maximum number of times to rescan targets to find volume
+# (integer value)
+# Deprecated group/name - [DEFAULT]/num_iscsi_scan_tries
+#num_volume_device_scan_tries=3
+
+# The backend name for a given driver implementation (string
+# value)
+#volume_backend_name=<None>
+<% if @use_multi_backend -%>
+volume_backend_name=<%= volume['backend_name'] %>
+<% end -%>
+
 # Do we attach/detach volumes in cinder using multipath for
 # volume to image and image to volume transfers? (boolean
 # value)
@@ -1117,6 +1036,11 @@ iscsi_ip_address = <%= volume["emc"]["emc_ecom_server_ip"] %>
 # Size in MiB to wipe at start of old volumes. 0 => all
 # (integer value)
 #volume_clear_size=0
+
+# The flag to pass to ionice to alter the i/o priority of the
+# process used to zero a volume after deletion, for example
+# "-c3" for idle only priority. (string value)
+#volume_clear_ionice=<None>
 
 # iscsi target user-land tool to use (string value)
 #iscsi_helper=tgtadm
@@ -1135,6 +1059,19 @@ iscsi_ip_address = <%= volume["emc"]["emc_ecom_server_ip"] %>
 # blockio or fileio optionally, auto can be set and Cinder
 # will autodetect type of backing device (string value)
 #iscsi_iotype=fileio
+
+# The default block size used when copying/clearing volumes
+# (string value)
+#volume_dd_blocksize=1M
+
+
+#
+# Options defined in cinder.volume.drivers.block_device
+#
+
+# List of all available devices (list value)
+#available_devices=
+
 
 <% if volume['backend_driver'] == 'coraid' -%>
 #
@@ -1157,8 +1094,9 @@ iscsi_ip_address = <%= volume["emc"]["emc_ecom_server_ip"] %>
 # Volume Type key name to store ESM Repository Name (string
 # value)
 #coraid_repository_key=coraid_repository
-<% end %>
 
+
+<% end -%>
 <% if volume['backend_driver'] == 'emc' -%>
 #
 # Options defined in cinder.volume.drivers.emc.emc_smis_common
@@ -1168,9 +1106,27 @@ iscsi_ip_address = <%= volume["emc"]["emc_ecom_server_ip"] %>
 # value)
 cinder_emc_config_file=/etc/cinder/cinder_emc_config-<%= backend_id %>.xml
 
-<% end %>
+
+#
+# Options defined in cinder.volume.drivers.emc.emc_vnx_cli
+#
+
+# Naviseccli Path (string value)
+#naviseccli_path=
+
+# ISCSI pool name (string value)
+#storage_vnx_pool_name=<None>
+
+# Default Time Out For CLI operations in minutes (integer
+# value)
+#default_timeout=20
+
+# Default max number of LUNs in a storage group (integer
+# value)
+#max_luns_per_storage_group=256
 
 
+<% end -%>
 <% if volume['backend_driver'] == 'eqlx' -%>
 #
 # Options defined in cinder.volume.drivers.eqlx
@@ -1186,7 +1142,7 @@ eqlx_cli_timeout=<%= volume['eqlx']["eqlx_cli_timeout"] %>
 # Maximum retry count for reconnection (integer value)
 #eqlx_cli_max_retries=5
 
-# Use CHAP authentificaion for targets? (boolean value)
+# Use CHAP authentication for targets? (boolean value)
 #eqlx_use_chap=false
 eqlx_use_chap=<%= volume['eqlx']["eqlx_use_chap"] %>
 
@@ -1199,9 +1155,9 @@ eqlx_chap_password=<%= volume['eqlx']["eqlx_chap_password"] %>
 # Pool in which volumes will be created (string value)
 eqlx_pool=<%= volume['eqlx']["eqlx_pool"] %>
 
-<% end -%>
 
-<% if volume['backend_driver'] == 'eqlx' -%>
+<% end -%>
+<% if volume['backend_driver'] == 'glusterfs' -%>
 #
 # Options defined in cinder.volume.drivers.glusterfs
 #
@@ -1209,9 +1165,6 @@ eqlx_pool=<%= volume['eqlx']["eqlx_pool"] %>
 # File with the list of available gluster shares (string
 # value)
 #glusterfs_shares_config=/etc/cinder/glusterfs_shares
-
-# Use du or df for free space calculation (string value)
-#glusterfs_disk_util=df
 
 # Create volumes as sparsed files which take no space.If set
 # to False volume is created as regular file.In such case
@@ -1226,11 +1179,32 @@ eqlx_pool=<%= volume['eqlx']["eqlx_pool"] %>
 # value)
 #glusterfs_mount_point_base=$state_path/mnt
 
-<% end -%>
 
+<% end -%>
+<% if volume['backend_driver'] == 'hds' -%>
+#
+# Options defined in cinder.volume.drivers.hds.hds
+#
+
+# configuration file for HDS cinder plugin for HUS (string
+# value)
+#hds_cinder_config_file=/opt/hds/hus/cinder_hus_conf.xml
+
+
+<% end -%>
+<% if volume['backend_driver'] == 'huawei' -%>
+#
+# Options defined in cinder.volume.drivers.huawei
+#
+
+# config data for cinder huawei plugin (string value)
+#cinder_huawei_conf_file=/etc/cinder/cinder_huawei_conf.xml
+
+
+<% end -%>
 <% if volume['backend_driver'] == 'gpfs' -%>
 #
-# Options defined in cinder.volume.drivers.gpfs
+# Options defined in cinder.volume.drivers.ibm.gpfs
 #
 
 # Specifies the path of the GPFS directory where Block Storage
@@ -1265,8 +1239,88 @@ eqlx_pool=<%= volume['eqlx']["eqlx_pool"] %>
 # created as a fully allocated file, in which case, creation
 # may take a significantly longer time. (boolean value)
 #gpfs_sparse_volumes=true
-<% end -%>
 
+# Specifies the storage pool that volumes are assigned to.  By
+# default, the system storage pool is used. (string value)
+#gpfs_storage_pool=<None>
+
+
+<% end -%>
+<% if volume['backend_driver'] == 'storewize_svc' -%>
+#
+# Options defined in cinder.volume.drivers.ibm.storwize_svc
+#
+
+# Storage system storage pool for volumes (string value)
+#storwize_svc_volpool_name=volpool
+
+# Storage system space-efficiency parameter for volumes
+# (percentage) (integer value)
+#storwize_svc_vol_rsize=2
+
+# Storage system threshold for volume capacity warnings
+# (percentage) (integer value)
+#storwize_svc_vol_warning=0
+
+# Storage system autoexpand parameter for volumes (True/False)
+# (boolean value)
+#storwize_svc_vol_autoexpand=true
+
+# Storage system grain size parameter for volumes
+# (32/64/128/256) (integer value)
+#storwize_svc_vol_grainsize=256
+
+# Storage system compression option for volumes (boolean
+# value)
+#storwize_svc_vol_compression=false
+
+# Enable Easy Tier for volumes (boolean value)
+#storwize_svc_vol_easytier=true
+
+# The I/O group in which to allocate volumes (integer value)
+#storwize_svc_vol_iogrp=0
+
+# Maximum number of seconds to wait for FlashCopy to be
+# prepared. Maximum value is 600 seconds (10 minutes) (integer
+# value)
+#storwize_svc_flashcopy_timeout=120
+
+# Connection protocol (iSCSI/FC) (string value)
+#storwize_svc_connection_protocol=iSCSI
+
+# Configure CHAP authentication for iSCSI connections
+# (Default: Enabled) (boolean value)
+#storwize_svc_iscsi_chap_enabled=true
+
+# Connect with multipath (FC only; iSCSI multipath is
+# controlled by Nova) (boolean value)
+#storwize_svc_multipath_enabled=false
+
+# Allows vdisk to multi host mapping (boolean value)
+#storwize_svc_multihostmap_enabled=true
+
+
+<% end -%>
+<% if volume['backend_driver'] == 'xiv_ds8k' -%>
+#
+# Options defined in cinder.volume.drivers.ibm.xiv_ds8k
+#
+
+# Proxy driver that connects to the IBM Storage Array (string
+# value)
+#xiv_ds8k_proxy=xiv_ds8k_openstack.nova_proxy.XIVDS8KNovaProxy
+
+# Connection type to the IBM Storage Array
+# (fibre_channel|iscsi) (string value)
+#xiv_ds8k_connection_type=iscsi
+
+# CHAP authentication mode, effective only for iscsi
+# (disabled|enabled) (string value)
+#xiv_chap=disabled
+
+
+<% end -%>
+<% if ['local', 'raw'].include? volume['backend_driver'] -%>
 #
 # Options defined in cinder.volume.drivers.lvm
 #
@@ -1275,8 +1329,7 @@ eqlx_pool=<%= volume['eqlx']["eqlx_pool"] %>
 # value)
 <% if volume['backend_driver'] == 'raw' -%>
 volume_group=<%= volume[:raw][:volume_name] %>
-<% end -%>
-<% if volume['backend_driver'] == 'local' -%>
+<% elsif volume['backend_driver'] == 'local' -%>
 volume_group=<%= volume[:local][:volume_name] %>
 <% end -%>
 
@@ -1294,6 +1347,7 @@ volume_group=<%= volume[:local][:volume_name] %>
 lvm_type=thin
 
 
+<% end -%>
 <% if volume['backend_driver'] == 'netapp' -%>
 #
 # Options defined in cinder.volume.drivers.netapp.options
@@ -1338,33 +1392,6 @@ netapp_server_hostname=<%= volume['netapp']['netapp_server_hostname'] %>
 # on the storage system or proxy server. (integer value)
 netapp_server_port=<%= volume['netapp']['netapp_server_port'] %>
 
-# This option is used to specify the path to the E-Series
-# proxy application on a proxy server. The value is combined
-# with the value of the netapp_transport_type,
-# netapp_server_hostname, and netapp_server_port options to
-# create the URL used by the driver to connect to the proxy
-# application. (string value)
-#netapp_webservice_path=/devmgr/v2
-
-# This option is only utilized when the storage family is
-# configured to eseries. This option is used to restrict
-# provisioning to the specified controllers. Specify the value
-# of this option to be a comma separated list of controller
-# hostnames or IP addresses to be used for provisioning.
-# (string value)
-#netapp_controller_ips=<None>
-
-# Password for the NetApp E-Series storage array. (string
-# value)
-#netapp_sa_password=<None>
-
-# This option is used to restrict provisioning to the
-# specified storage pools. Only dynamic disk pools are
-# currently supported. Specify the value of this option to be
-# a comma separated list of disk pool names to be used for
-# provisioning. (string value)
-#netapp_storage_pools=<None>
-
 # If the percentage of available space for an NFS share has
 # dropped below the value specified by this option, the NFS
 # image cache will be cleaned. (integer value)
@@ -1385,12 +1412,6 @@ netapp_server_port=<%= volume['netapp']['netapp_server_port'] %>
 # will be deleted from the cache to create free space on the
 # NFS share. (integer value)
 #expiry_thres_minutes=720
-
-# This option specifies the path of the NetApp copy offload
-# tool binary. Ensure that the binary has execute permissions
-# set which allow the effective user of the cinder-volume
-# process to execute the file. (string value)
-#netapp_copyoffload_tool_path=<None>
 
 # The quantity to be multiplied by the requested volume size
 # to ensure enough space is available on the virtual storage
@@ -1422,12 +1443,8 @@ netapp_storage_protocol=<%= volume['netapp']['storage_protocol'] %>
 # https. (string value)
 netapp_transport_type=<%= volume['netapp']['netapp_transport_type'] %>
 
-# File with the list of available nfs shares (string value)
-nfs_shares_config=/etc/cinder/nfs_shares-<%= backend_id %>
 
 <% end -%>
-
-
 <% if volume['backend_driver'] == 'nexenta' -%>
 #
 # Options defined in cinder.volume.drivers.nexenta.options
@@ -1478,36 +1495,52 @@ nfs_shares_config=/etc/cinder/nfs_shares-<%= backend_id %>
 # value)
 #nexenta_volume_compression=on
 
-# Mount options passed to the nfs client. See section of the
-# nfs man page for details (string value)
-#nexenta_mount_options=<None>
+# If set True cache NexentaStor appliance volroot option
+# value. (boolean value)
+#nexenta_nms_cache_volroot=true
 
-# Percent of ACTUAL usage of the underlying volume before no
-# new volumes can be allocated to the volume destination.
-# (floating point value)
-#nexenta_used_ratio=0.95
+# Enable stream compression, level 1..9. 1 - gives best speed;
+# 9 - gives best compression. (integer value)
+#nexenta_rrmgr_compression=0
 
-# This will compare the allocated to available space on the
-# volume destination.  If the ratio exceeds this number, the
-# destination will no longer be valid. (floating point value)
-#nexenta_oversub_ratio=1.0
+# TCP Buffer size in KiloBytes. (integer value)
+#nexenta_rrmgr_tcp_buf_size=4096
+
+# Number of TCP connections. (integer value)
+#nexenta_rrmgr_connections=2
 
 # block size for volumes (blank=default,8KB) (string value)
 #nexenta_blocksize=
 
 # flag to create sparse volumes (boolean value)
 #nexenta_sparse=false
+
+
 <% end -%>
-
-
+<% if ['netapp'].include? volume['backend_driver'] -%>
 #
 # Options defined in cinder.volume.drivers.nfs
 #
 
-<% if volume['backend_driver'] == 'netapp' -%>
+# IP address or Hostname of NAS system. (string value)
+#nas_ip=
+
+# User name to connect to NAS system. (string value)
+#nas_login=admin
+
+# Password to connect to NAS system. (string value)
+#nas_password=
+
+# SSH port to use to connect to NAS system. (integer value)
+#nas_ssh_port=22
+
+# Filename of private key to use for SSH authentication.
+# (string value)
+#nas_private_key=
+
 # File with the list of available nfs shares (string value)
 nfs_shares_config=/etc/cinder/nfs_shares-<%= backend_id %>
-<% end -%>
+
 
 # Create volumes as sparsed files which take no space.If set
 # to False volume is created as regular file.In such case
@@ -1533,6 +1566,7 @@ nfs_shares_config=/etc/cinder/nfs_shares-<%= backend_id %>
 #nfs_mount_options=<None>
 
 
+<% end -%>
 <% if volume['backend_driver'] == 'rbd' -%>
 #
 # Options defined in cinder.volume.drivers.rbd
@@ -1544,6 +1578,7 @@ rbd_pool=<%= volume['rbd']['pool'] %>
 
 # the RADOS client name for accessing rbd volumes - only set
 # when using cephx authentication (string value)
+#rbd_user=
 <% unless volume['rbd']['user'].empty? -%>
 rbd_user=<%= volume['rbd']['user'] %>
 <% end -%>
@@ -1572,9 +1607,9 @@ rbd_ceph_conf=<%= volume['rbd']['config_file'] %>
 # value of zero disables cloning (integer value)
 #rbd_max_clone_depth=5
 
-<% end -%>
 
-<% if volume['backend_driver'] == 'hp' -%>
+<% end -%>
+<% if volume['backend_driver'] == 'hp_3par' -%>
 #
 # Options defined in cinder.volume.drivers.san.hp.hp_3par_common
 #
@@ -1588,10 +1623,6 @@ rbd_ceph_conf=<%= volume['rbd']['config_file'] %>
 
 # 3PAR Super user password (string value)
 #hp3par_password=
-
-# This option is DEPRECATED and no longer used. The 3par
-# domain name to use. (string value)
-#hp3par_domain=<None>
 
 # The CPG to use for volume creation (string value)
 #hp3par_cpg=OpenStack
@@ -1613,10 +1644,47 @@ rbd_ceph_conf=<%= volume['rbd']['config_file'] %>
 
 # List of target iSCSI addresses to use. (list value)
 #hp3par_iscsi_ips=
+
+
 <% end -%>
+<% if volume['backend_driver'] == 'hp_lefthand' -%>
+#
+# Options defined in cinder.volume.drivers.san.hp.hp_lefthand_rest_proxy
+#
+
+# HP LeftHand WSAPI Server Url like https://<LeftHand
+# ip>:8081/lhos (string value)
+#hplefthand_api_url=<None>
+
+# HP LeftHand Super user username (string value)
+#hplefthand_username=<None>
+
+# HP LeftHand Super user password (string value)
+#hplefthand_password=<None>
+
+# HP LeftHand cluster name (string value)
+#hplefthand_clustername=<None>
+
+# Configure CHAP authentication for iSCSI connections
+# (Default: Disabled) (boolean value)
+#hplefthand_iscsi_chap_enabled=false
+
+# Enable HTTP debugging to LeftHand (boolean value)
+#hplefthand_debug=false
 
 
-<% if volume['backend_driver'] == 'eqlx' -%>
+<% end -%>
+<% if volume['backend_driver'] == 'hp_msa' -%>
+#
+# Options defined in cinder.volume.drivers.san.hp.hp_msa_common
+#
+
+# The VDisk to use for volume creation. (string value)
+#msa_vdisk=OpenStack
+
+
+<% end -%>
+<% if ['eqlx'].include? volume['backend_driver'] -%>
 #
 # Options defined in cinder.volume.drivers.san.san
 #
@@ -1655,9 +1723,10 @@ san_password=<%= volume['eqlx']["san_password"] %>
 
 # Maximum ssh connections in the pool (integer value)
 #ssh_max_pool_conn=5
-<% end -%>
 
-<% if volume['backend_driver'] == 'eqlx' -%>
+
+<% end -%>
+<% if volume['backend_driver'] == 'solaris' -%>
 #
 # Options defined in cinder.volume.drivers.san.solaris
 #
@@ -1665,8 +1734,9 @@ san_password=<%= volume['eqlx']["san_password"] %>
 # The ZFS path under which to create zvols for volumes.
 # (string value)
 #san_zfs_volume_base=rpool/
-<% end -%>
 
+
+<% end -%>
 <% if volume['backend_driver'] == 'scality' -%>
 #
 # Options defined in cinder.volume.drivers.scality
@@ -1681,9 +1751,9 @@ san_password=<%= volume['eqlx']["san_password"] %>
 
 # Path from Scality SOFS root to volume dir (string value)
 #scality_sofs_volume_dir=cinder/volumes
+
+
 <% end -%>
-
-
 <% if volume['backend_driver'] == 'solidfire' -%>
 #
 # Options defined in cinder.volume.drivers.solidfire
@@ -1695,69 +1765,18 @@ san_password=<%= volume['eqlx']["san_password"] %>
 # Allow tenants to specify QOS on create (boolean value)
 #sf_allow_tenant_qos=false
 
-# Create SolidFire accounts with this prefix (string value)
-#sf_account_prefix=cinder
+# Create SolidFire accounts with this prefix. Any string can
+# be used here, but the string "hostname" is special and will
+# create a prefix using the cinder node hostsname (previous
+# default behavior).  The default is NO prefix. (string value)
+#sf_account_prefix=<None>
 
 # SolidFire API port. Useful if the device api is behind a
 # proxy on a different port. (integer value)
 #sf_api_port=443
+
+
 <% end -%>
-
-
-<% if volume['backend_driver'] == 'storewize_svc' -%>
-#
-# Options defined in cinder.volume.drivers.storwize_svc
-#
-
-# Storage system storage pool for volumes (string value)
-#storwize_svc_volpool_name=volpool
-
-# Storage system space-efficiency parameter for volumes
-# (percentage) (integer value)
-#storwize_svc_vol_rsize=2
-
-# Storage system threshold for volume capacity warnings
-# (percentage) (integer value)
-#storwize_svc_vol_warning=0
-
-# Storage system autoexpand parameter for volumes (True/False)
-# (boolean value)
-#storwize_svc_vol_autoexpand=true
-
-# Storage system grain size parameter for volumes
-# (32/64/128/256) (integer value)
-#storwize_svc_vol_grainsize=256
-
-# Storage system compression option for volumes (boolean
-# value)
-#storwize_svc_vol_compression=false
-
-# Enable Easy Tier for volumes (boolean value)
-#storwize_svc_vol_easytier=true
-
-# The I/O group in which to allocate volumes (integer value)
-#storwize_svc_vol_iogrp=0
-
-# Maximum number of seconds to wait for FlashCopy to be
-# prepared. Maximum value is 600 seconds (10 minutes) (integer
-# value)
-#storwize_svc_flashcopy_timeout=120
-
-# Connection protocol (iSCSI/FC) (string value)
-#storwize_svc_connection_protocol=iSCSI
-
-# Configure CHAP authentication for iSCSI connections
-# (Default: Enabled) (boolean value)
-#storwize_svc_iscsi_chap_enabled=true
-
-# Connect with multipath (FC only; iSCSI multipath is
-# controlled by Nova) (boolean value)
-#storwize_svc_multipath_enabled=false
-
-# Allows vdisk to multi host mapping (boolean value)
-#storwize_svc_multihostmap_enabled=true
-<% end -%>
-
 <% if volume['backend_driver'] == 'vmware' -%>
 #
 # Options defined in cinder.volume.drivers.vmware.vmdk
@@ -1784,8 +1803,8 @@ vmware_host_password=<%= volume['vmware']["password"] %>
 # upon connection related issues. (integer value)
 #vmware_api_retry_count=10
 
-# The interval used for polling remote tasks invoked on VMware
-# ESX/VC server. (integer value)
+# The interval (in seconds) for polling remote tasks invoked
+# on VMware ESX/VC server. (integer value)
 #vmware_task_poll_interval=5
 
 # Name for the folder in the VC datacenter that will contain
@@ -1801,8 +1820,15 @@ vmware_volume_folder=<%= volume['vmware']["volume"] %>
 # in one shot. Server may still limit the count to something
 # less than the configured value. (integer value)
 #vmware_max_objects_retrieval=100
-<% end -%>
 
+# Optional string specifying the VMware VC server version. The
+# driver attempts to retrieve the version from VMware VC
+# server. Set this configuration only if you want to override
+# the VC server version. (string value)
+#vmware_host_version=<None>
+
+
+<% end -%>
 <% if volume['backend_driver'] == 'windows' -%>
 #
 # Options defined in cinder.volume.drivers.windows.windows
@@ -1810,9 +1836,10 @@ vmware_volume_folder=<%= volume['vmware']["volume"] %>
 
 # Path to store VHD backed volumes (string value)
 #windows_iscsi_lun_path=C:\iSCSIVirtualDisks
-<% end -%>
 
-<% if volume['backend_driver'] == 'xen' -%>
+
+<% end -%>
+<% if volume['backend_driver'] == 'xenapi' -%>
 #
 # Options defined in cinder.volume.drivers.xenapi.sm
 #
@@ -1834,24 +1861,9 @@ vmware_volume_folder=<%= volume['vmware']["volume"] %>
 
 # Base path to the storage repository (string value)
 #xenapi_sr_base_path=/var/run/sr-mount
+
+
 <% end -%>
-
-
-<% if volume['backend_driver'] == 'xiv_ds8k' -%>
-#
-# Options defined in cinder.volume.drivers.xiv_ds8k
-#
-
-# Proxy driver that connects to the IBM Storage Array (string
-# value)
-#xiv_ds8k_proxy=xiv_ds8k_openstack.nova_proxy.XIVDS8KNovaProxy
-
-# Connection type to the IBM Storage Array
-# (fibre_channel|iscsi) (string value)
-#xiv_ds8k_connection_type=iscsi
-<% end -%>
-
-
 <% if volume['backend_driver'] == 'zadara' -%>
 #
 # Options defined in cinder.volume.drivers.zadara
@@ -1881,12 +1893,6 @@ vmware_volume_folder=<%= volume['vmware']["volume"] %>
 # Default encryption policy for volumes (boolean value)
 #zadara_vol_encrypt=false
 
-# Default striping mode for volumes (string value)
-#zadara_default_striping_mode=simple
-
-# Default stripe size for volumes (string value)
-#zadara_default_stripesize=64
-
 # Default template for VPSA volume names (string value)
 #zadara_vol_name_template=OS_%s
 
@@ -1897,9 +1903,9 @@ vmware_volume_folder=<%= volume['vmware']["volume"] %>
 # Don't halt on deletion of non-existing volumes (boolean
 # value)
 #zadara_vpsa_allow_nonexistent_delete=true
+
+
 <% end -%>
-
-
 <% if volume['backend_driver'] == 'eternus' -%>
 #
 # Options defined in cinder.volume.drivers.fujitsu.fujitsu_eternus_dx_common
@@ -1908,25 +1914,22 @@ vmware_volume_folder=<%= volume['vmware']["volume"] %>
 # Use this file for cinder Fujitsu ETERNUS DX plugin config data
 # (string value)
 cinder_eternus_config_file=/etc/cinder/cinder_eternus_dx_config-<%= backend_id %>.xml
-<% end -%>
 
+
+<% end -%>
 #
 # Options defined in cinder.volume.manager
 #
 
 # Driver to use for volume creation (string value)
-#volume_driver=cinder.volume.drivers.lvm.LVMISCSIDriver
-<% if volume['backend_driver'] == 'rbd' -%>
-volume_driver=cinder.volume.drivers.rbd.RBDDriver
-<% end -%>
-<% if volume['backend_driver'] == 'eqlx' -%>
-volume_driver=cinder.volume.drivers.eqlx.DellEQLSanISCSIDriver
-<% end -%>
-<% if volume['backend_driver'] == 'netapp' -%>
-volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
+<% if ['local', 'raw'].include? volume['backend_driver'] -%>
+volume_driver=cinder.volume.drivers.lvm.LVMISCSIDriver
 <% end -%>
 <% if volume['backend_driver'] == 'emc' -%>
 volume_driver=cinder.volume.drivers.emc.emc_smis_iscsi.EMCSMISISCSIDriver
+<% end -%>
+<% if volume['backend_driver'] == 'eqlx' -%>
+volume_driver=cinder.volume.drivers.eqlx.DellEQLSanISCSIDriver
 <% end -%>
 <% if volume['backend_driver'] == 'eternus' -%>
   <% if volume['eternus']['protocol'] == "iscsi" -%>
@@ -1934,6 +1937,12 @@ volume_driver=cinder.volume.drivers.fujitsu.fujitsu_eternus_dx_iscsi.FJDXISCSIDr
   <% else -%>
 volume_driver=cinder.volume.drivers.fujitsu.fujitsu_eternus_dx_fc.FJDXFCDriver
   <% end -%>
+<% end -%>
+<% if volume['backend_driver'] == 'netapp' -%>
+volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
+<% end -%>
+<% if volume['backend_driver'] == 'rbd' -%>
+volume_driver=cinder.volume.drivers.rbd.RBDDriver
 <% end -%>
 <% if volume['backend_driver'] == 'vmware' -%>
 volume_driver=cinder.volume.drivers.vmware.vmdk.VMwareVcVmdkDriver
@@ -1943,12 +1952,177 @@ volume_driver=<%= volume['manual']['driver'] %>
 <%= volume['manual']['config'] %>
 <% end -%>
 
-<% break unless @use_multi_backend -%>
-<% end %>
+# Timeout for creating the volume to migrate to when
+# performing volume migration (seconds) (integer value)
+#migration_create_volume_timeout_secs=300
 
+# Offload pending volume delete during volume service startup
+# (boolean value)
+#volume_service_inithost_offload=false
+
+# FC Zoning mode configured (string value)
+#zoning_mode=none
+
+# User defined capabilities, a JSON formatted string
+# specifying key/value pairs. (string value)
+#extra_capabilities={}
+<% break unless @use_multi_backend -%>
+<% end -%>
+
+
+#############################################################################
 #############################################################################
 ## END Cinder backends
 #############################################################################
+#############################################################################
+
+
+[BRCD_FABRIC_EXAMPLE]
+
+#
+# Options defined in cinder.zonemanager.drivers.brocade.brcd_fabric_opts
+#
+
+# Management IP of fabric (string value)
+#fc_fabric_address=
+
+# Fabric user ID (string value)
+#fc_fabric_user=
+
+# Password for user (string value)
+#fc_fabric_password=
+
+# Connecting port (integer value)
+#fc_fabric_port=22
+
+# overridden zoning policy (string value)
+#zoning_policy=initiator-target
+
+# overridden zoning activation state (boolean value)
+#zone_activate=true
+
+# overridden zone name prefix (string value)
+#zone_name_prefix=<None>
+
+# Principal switch WWN of the fabric (string value)
+#principal_switch_wwn=<None>
+
+
+[database]
+
+#
+# Options defined in cinder.openstack.common.db.api
+#
+
+# The backend to use for db (string value)
+# Deprecated group/name - [DEFAULT]/db_backend
+#backend=sqlalchemy
+
+# Enable the experimental use of thread pooling for all DB API
+# calls (boolean value)
+# Deprecated group/name - [DEFAULT]/dbapi_use_tpool
+#use_tpool=false
+
+
+#
+# Options defined in cinder.openstack.common.db.sqlalchemy.session
+#
+
+# The SQLAlchemy connection string used to connect to the
+# database (string value)
+# Deprecated group/name - [DEFAULT]/sql_connection
+connection=<%= @sql_connection %>
+
+# timeout before idle sql connections are reaped (integer
+# value)
+# Deprecated group/name - [DEFAULT]/sql_idle_timeout
+#idle_timeout=3600
+
+# Minimum number of SQL connections to keep open in a pool
+# (integer value)
+# Deprecated group/name - [DEFAULT]/sql_min_pool_size
+#min_pool_size=1
+
+# Maximum number of SQL connections to keep open in a pool
+# (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_pool_size
+#max_pool_size=5
+
+# maximum db connection retries during startup. (setting -1
+# implies an infinite retry count) (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_retries
+#max_retries=10
+
+# interval between retries of opening a sql connection
+# (integer value)
+# Deprecated group/name - [DEFAULT]/sql_retry_interval
+#retry_interval=10
+
+# If set, use this value for max_overflow with sqlalchemy
+# (integer value)
+# Deprecated group/name - [DEFAULT]/sql_max_overflow
+#max_overflow=<None>
+
+# Verbosity of SQL debugging information. 0=None,
+# 100=Everything (integer value)
+# Deprecated group/name - [DEFAULT]/sql_connection_debug
+#connection_debug=0
+
+# Add python stack traces to SQL as comment strings (boolean
+# value)
+# Deprecated group/name - [DEFAULT]/sql_connection_trace
+#connection_trace=false
+
+
+[fc-zone-manager]
+
+#
+# Options defined in cinder.zonemanager.drivers.brocade.brcd_fc_zone_driver
+#
+
+# Southbound connector for zoning operation (string value)
+#brcd_sb_connector=cinder.zonemanager.drivers.brocade.brcd_fc_zone_client_cli.BrcdFCZoneClientCLI
+
+
+#
+# Options defined in cinder.zonemanager.fc_zone_manager
+#
+
+# FC Zone Driver responsible for zone management (string
+# value)
+#zone_driver=cinder.zonemanager.drivers.brocade.brcd_fc_zone_driver.BrcdFCZoneDriver
+
+# Zoning policy configured by user (string value)
+#zoning_policy=initiator-target
+
+# Comma separated list of fibre channel fabric names. This
+# list of names is used to retrieve other SAN credentials for
+# connecting to each SAN fabric (string value)
+#fc_fabric_names=<None>
+
+# FC San Lookup Service (string value)
+#fc_san_lookup_service=cinder.zonemanager.drivers.brocade.brcd_fc_san_lookup_service.BrcdFCSanLookupService
+
+
+[keymgr]
+
+#
+# Options defined in cinder.keymgr
+#
+
+# The full class name of the key manager API class (string
+# value)
+#api_class=cinder.keymgr.conf_key_mgr.ConfKeyManager
+
+
+#
+# Options defined in cinder.keymgr.conf_key_mgr
+#
+
+# Fixed key returned by key manager, specified in hex (string
+# value)
+#fixed_key=<None>
+
 
 [keystone_authtoken]
 
@@ -1997,15 +2171,12 @@ identity_uri = <%= @keystone_settings['admin_auth_url'] %>
 # with Identity API Server. (integer value)
 #http_request_max_retries=3
 
-# Allows to pass in the name of a fake http_handler callback
-# function used instead of httplib.HTTPConnection or
-# httplib.HTTPSConnection. Useful for unit testing where
-# network is not available. (string value)
-#http_handler=<None>
-
-# Single shared secret with the Keystone configuration used
-# for bootstrapping a Keystone installation, or otherwise
-# bypassing the normal authentication process. (string value)
+# This option is deprecated and may be removed in a future
+# release. Single shared secret with the Keystone
+# configuration used for bootstrapping a Keystone
+# installation, or otherwise bypassing the normal
+# authentication process. This option should not be used, use
+# `admin_user` and `admin_password` instead. (string value)
 #admin_token=<None>
 
 # Keystone account username (string value)
@@ -2040,20 +2211,24 @@ insecure = <%= @keystone_settings['insecure'] %>
 # value)
 signing_dir=/var/cache/cinder/keystone-signing
 
-# If defined, the memcache server(s) to use for caching (list
-# value)
+# Optionally specify a list of memcached server(s) to use for
+# caching. If left undefined, tokens will instead be cached
+# in-process. (list value)
 # Deprecated group/name - [DEFAULT]/memcache_servers
 #memcached_servers=<None>
 
-# In order to prevent excessive requests and validations, the
-# middleware uses an in-memory cache for the tokens the
-# Keystone API returns. This is only valid if memcache_servers
-# is defined. Set to -1 to disable caching completely.
-# (integer value)
+# In order to prevent excessive effort spent validating
+# tokens, the middleware caches previously-seen tokens for a
+# configurable duration (in seconds). Set to -1 to disable
+# caching completely. (integer value)
 #token_cache_time=300
 
-# Value only used for unit testing (integer value)
-#revocation_cache_time=1
+# Determines the frequency at which the list of revoked tokens
+# is retrieved from the Identity service (in seconds). A high
+# number of revocation events combined with a low cache
+# duration may significantly reduce performance. (integer
+# value)
+#revocation_cache_time=10
 
 # (optional) if defined, indicate whether token data should be
 # authenticated or authenticated and encrypted. Acceptable
@@ -2074,5 +2249,63 @@ signing_dir=/var/cache/cinder/keystone-signing
 # catalog on token validation and will not set the X-Service-
 # Catalog header. (boolean value)
 #include_service_catalog=true
+
+# Used to control the use and type of token binding. Can be
+# set to: "disabled" to not check token binding. "permissive"
+# (default) to validate binding information if the bind type
+# is of a form known to the server and ignore it if not.
+# "strict" like "permissive" but if the bind type is unknown
+# the token will be rejected. "required" any form of token
+# binding is needed to be allowed. Finally the name of a
+# binding method that must be present in tokens. (string
+# value)
+#enforce_token_bind=permissive
+
+# If true, the revocation list will be checked for cached
+# tokens. This requires that PKI tokens are configured on the
+# Keystone server. (boolean value)
+#check_revocations_for_cached=false
+
+# Hash algorithms to use for hashing PKI tokens. This may be a
+# single algorithm or multiple. The algorithms are those
+# supported by Python standard hashlib.new(). The hashes will
+# be tried in the order given, so put the preferred one first
+# for performance. The result of the first hash will be stored
+# in the cache. This will typically be set to multiple values
+# only while migrating from a less secure algorithm to a more
+# secure one. Once all the old tokens are expired this option
+# should be set to a single value for better performance.
+# (list value)
+#hash_algorithms=md5
+
+
+[matchmaker_ring]
+
+#
+# Options defined in oslo.messaging
+#
+
+# Matchmaker ring file (JSON). (string value)
+# Deprecated group/name - [DEFAULT]/matchmaker_ringfile
+#ringfile=/etc/oslo/matchmaker_ring.json
+
+
+[ssl]
+
+#
+# Options defined in cinder.openstack.common.sslutils
+#
+
+# CA certificate file to use to verify connecting clients
+# (string value)
+#ca_file=<None>
+
+# Certificate file to use when starting the server securely
+# (string value)
+#cert_file=<None>
+
+# Private key file to use when starting the server securely
+# (string value)
+#key_file=<None>
 
 


### PR DESCRIPTION
There's no functional change yet.

Note that some new options for NetApp were not added yet (so are still
in the diff) because we need to figure out if we care about them. These
are:
  netapp_webservice_path
  netapp_controller_ips
  netapp_sa_password
  netapp_storage_pools
  netapp_copyoffload_tool_path
