### PR TITLE
Switch emc config ownership

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -178,8 +178,8 @@ if node[:cinder][:volume][:volume_type] == "emc"
 
   template "/etc/cinder/cinder_emc_config.xml" do
     source "cinder_emc_config.xml.erb"
-    owner node[:cinder][:user]
-    group "root"
+    owner "root"
+    group node[:cinder][:group]
     mode 0640
     variables(
               :emc_params => emc_params


### PR DESCRIPTION
As suggested at
https://github.com/SUSE-Cloud/barclamp-cinder/pull/1#discussion-diff-14992181
i have switched owner and group for the emc volume type config file.
