### PR TITLE
Integrated Fujitsu ETERNUS DX (fate#317486)

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -189,6 +189,23 @@ else
   emc_params = nil
 end
 
+if node[:cinder][:volume][:volume_type] == "eternus"
+  Chef::Log.info("Pushing Eternus params to cinder.conf template")
+  eternus_params = node[:cinder][:volume][:eternus]
+
+  template "/etc/cinder/cinder_eternus_dx_config.xml" do
+    source "cinder_eternus_dx_config.xml.erb"
+    owner "root"
+    group node[:cinder][:group]
+    mode 0640
+    variables(
+              :eternus_params => eternus_params
+             )
+  end
+else
+  eternus_params = nil
+end
+
 if node[:cinder][:volume][:volume_type] == "rbd"
   Chef::Log.info("Pushing Rbd params to cinder.conf template")
   rbd_params = node[:cinder][:volume][:rbd]
@@ -311,6 +328,7 @@ template "/etc/cinder/cinder.conf" do
     :local_params => local_params,
     :eqlx_params => eqlx_params,
     :emc_params => emc_params,
+    :eternus_params => eternus_params,
     :rbd_params => rbd_params,
     :netapp_params => netapp_params,
     :manual_driver => manual_driver,

--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -127,6 +127,7 @@ when node[:cinder][:volume][:volume_type] == "netapp"
 when node[:cinder][:volume][:volume_type] == "emc"
 when node[:cinder][:volume][:volume_type] == "manual"
 when node[:cinder][:volume][:volume_type] == "rbd"
+when node[:cinder][:volume][:volume_type] == "eternus"
 end
 
 unless %w(redhat centos).include? node.platform

--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -1208,6 +1208,16 @@ eqlx_pool=<%= @eqlx_params["eqlx_pool"] %>
 # value)
 #glusterfs_mount_point_base=$state_path/mnt
 
+<% if volume['backend_driver'] == 'eternus' -%>
+#
+# Options defined in cinder.volume.drivers.fujitsu.fujitsu_eternus_dx_common
+#
+
+# Use this file for cinder Fujitsu ETERNUS DX plugin config data
+# (string value)
+cinder_eternus_config_file=/etc/cinder/cinder_eternus_dx_config.xml
+
+<% end %>
 
 #
 # Options defined in cinder.volume.drivers.gpfs
@@ -1849,6 +1859,13 @@ volume_driver=cinder.volume.drivers.netapp.common.NetAppDriver
 <% end -%>
 <% unless @emc_params.nil? -%>
 volume_driver=cinder.volume.drivers.emc.emc_smis_iscsi.EMCSMISISCSIDriver
+<% end -%>
+<% unless @eternus_params.nil? -%>
+<% if @eternus_params["protocol"] == "iscsi" -%>
+volume_driver=cinder.volume.drivers.fujitsu.fujitsu_eternus_dx_iscsi.FJDXISCSIDriver
+<% else -%>
+volume_driver=cinder.volume.drivers.fujitsu.fujitsu_eternus_dx_fc.FJDXFCDriver
+<% end -%>
 <% end -%>
 <% unless @manual_driver.nil? -%>
 volume_driver=<%= @manual_driver %>

--- a/chef/cookbooks/cinder/templates/default/cinder_eternus_dx_config.xml.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder_eternus_dx_config.xml.erb
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<FUJITSU>
+<EternusIP><%= @eternus_params["ip"] %></EternusIP>
+<EternusPort><%= @eternus_params["port"] %></EternusPort>
+<EternusUser><%= @eternus_params["user"] %></EternusUser>
+<EternusPassword><%= @eternus_params["password"] %></EternusPassword>
+<EternusPool><%= @eternus_params["pool"] %></EternusPool>
+<EternusISCSIIP><% if @eternus_params["protocol"] == "iscsi" %><%= @eternus_params["iscsi_ip"] %><% end %></EternusISCSIIP>
+</FUJITSU>

--- a/chef/data_bags/crowbar/bc-template-cinder.json
+++ b/chef/data_bags/crowbar/bc-template-cinder.json
@@ -77,6 +77,15 @@
           "ecom_server_username": "admin",
           "ecom_server_password": ""
         },
+        "eternus": {
+          "protocol": "fc",
+          "ip": "",
+          "port": 5988,
+          "user": "",
+          "password": "",
+          "pool": "",
+          "iscsi_ip": ""
+        },
         "rbd": {
           "pool": "volumes",
           "user": "volumes"
@@ -111,7 +120,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 10,
+      "schema-revision": 11,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-cinder.schema
+++ b/chef/data_bags/crowbar/bc-template-cinder.schema
@@ -86,6 +86,17 @@
                     "ecom_server_password": { "type": "str", "required": true }
                   }
                 },
+                "eternus": {
+                  "type": "map", "required": true, "mapping": {
+                    "protocol": { "type": "str", "required": true },
+                    "ip": { "type": "str", "required": true },
+                    "port": { "type": "int", "required": true },
+                    "user": { "type": "str", "required": true },
+                    "password": { "type": "str", "required": true },
+                    "pool": { "type": "str", "required": true },
+                    "iscsi_ip": { "type": "str", "required": true }
+                  }
+                },
                 "rbd": {
                   "type": "map", "required": true, "mapping": {
                     "pool": { "type": "str", "required": true },

--- a/chef/data_bags/crowbar/migrate/cinder/011_eternus_dx_volume.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/011_eternus_dx_volume.rb
@@ -1,0 +1,9 @@
+def upgrade ta, td, a, d
+  a["volume"]["eternus"] = ta["volume"]["eternus"]
+  return a, d
+end
+
+def downgrade ta, td, a, d
+  a["volume"].delete("eternus")
+  return a, d
+end

--- a/crowbar_framework/app/assets/javascripts/barclamps/cinder/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/cinder/application.js
@@ -26,7 +26,8 @@ $(document).ready(function($) {
       'manual',
       'local',
       'rbd',
-      'raw'
+      'raw',
+      'eternus'
     ];
 
     var selector = $.map(types, function(val, index) {

--- a/crowbar_framework/app/helpers/barclamp/cinder_helper.rb
+++ b/crowbar_framework/app/helpers/barclamp/cinder_helper.rb
@@ -25,6 +25,7 @@ module Barclamp
           [t(".volume.netapp_volume_type"), "netapp"],
           [t(".volume.emc_volume_type"), "emc"],
           [t(".volume.eqlx_volume_type"), "eqlx"],
+          [t(".volume.eternus_volume_type"), "eternus"],
           [t(".volume.rbd_volume_type"), "rbd"],
           [t(".volume.manual_volume_type"), "manual"]
         ],
@@ -67,6 +68,16 @@ module Barclamp
         [
           ["HTTP", "http"],
           ["HTTPS", "https"]
+        ],
+        selected.to_s
+      )
+    end
+
+    def eternus_protocols_for_cinder(selected)
+      options_for_select(
+        [
+          ["iSCSI", "iscsi"],
+          ["FibreChannel", "fc"]
         ],
         selected.to_s
       )

--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -76,6 +76,19 @@
         = password_field %w(volume eqlx eqlx_chap_password)
         = integer_field %w(volume eqlx eqlx_cli_timeout)
 
+    #eternus_container
+      %fieldset
+        %legend
+          = t('.volume.eternus_parameters')
+
+        = select_field %w(volume eternus protocol), :collection => :eternus_protocols_for_cinder, "data-showit" => "iscsi", "data-showit-target" => "#volume_eternus_iscsi_ip"
+        = string_field %w(volume eternus ip)
+        = integer_field %w(volume eternus port)
+        = string_field %w(volume eternus user)
+        = password_field %w(volume eternus password)
+        = string_field %w(volume eternus pool)
+        = string_field %w(volume eternus iscsi_ip)
+
     #rbd_container
       %fieldset
         %legend

--- a/crowbar_framework/config/locales/cinder/en.yml
+++ b/crowbar_framework/config/locales/cinder/en.yml
@@ -54,7 +54,6 @@ en:
             netapp_vfiler: 'The vFiler unit name if using vFiler to host OpenStack volumes'
             nfs_shares: 'List of Netapp NFS Exports'
             nfs_shares_config_hint: 'Format one entry per line in the form hostname:/vol/path optional-nfs-mount-options'
-
           emc_volume_type: 'EMC'
           emc_parameters: 'EMC Parameters'
           emc:
@@ -77,6 +76,16 @@ en:
             eqlx_chap_login: 'EQLX chap login for targets'
             eqlx_chap_password: 'EQLX chap password for targets'
             eqlx_cli_timeout: 'EQLX CLI command execution timeout'
+          eternus_volume_type: 'Fujitsu ETERNUS DX'
+          eternus_parameters: 'Fujitsu ETERNUS DX Parameters'
+          eternus:
+            protocol: 'ETERNUS Connection Protocol'
+            ip: 'ETERNUS IP for SMIS'
+            port: 'ETERNUS Port for SMIS'
+            user: 'ETERNUS Username for SMIS'
+            password: 'ETERNUS Password for SMIS'
+            pool: 'ETERNUS Poolname'
+            iscsi_ip: 'iSCSI IP'
           manual_volume_type: 'Other Driver'
           manual_parameters: 'Other driver parameters'
           manual:


### PR DESCRIPTION
**An upstream followup pull request of https://github.com/SUSE-Cloud/barclamp-cinder/pull/1**

In order to get Fujitsu ETERNUS DX volume types working a have
integrated the configuration for it to reflect the patch included into
our SUSE packages.

This fixes the request https://fate.suse.com/317486
