### PR TITLE
Fix the fix for useless backend header in UI

### DIFF
--- a/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/cinder/_edit_attributes.html.haml
@@ -12,6 +12,7 @@
       %div#cinder_backends
         {{#each entries}}
         %ul.list-group(id="volume-entry-{{@index}}")
+          {{#if ../use_multi_backend }}
           %li.list-group-item.active
             %h3.list-group-item-heading
               Backend: {{ backend_name }}
@@ -19,6 +20,7 @@
               {{else}}
               = link_to icon_tag("trash"), "#", :class => "volume-backend-delete pull-right delete", "data-volumeid" => "{{@index}}"
               {{/if}}
+          {{/if}}
 
           {{#if_eq backend_driver 'raw'}}
           %li.list-group-item


### PR DESCRIPTION
It broke the "allow multibackend but use only one backend" case.
