### PR TITLE
Fix upgrade from roxy

### DIFF
--- a/chef/data_bags/crowbar/migrate/cinder/015_rename_vmware_volume_folder.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/015_rename_vmware_volume_folder.rb
@@ -1,5 +1,11 @@
 def upgrade ta, td, a, d
-  a['volume_defaults']['vmware']['volume_folder'] = a['volume_defaults']['vmware']['volume']
+  # Careful: upgrading from roxy: the 'volume' attribute will not even exist,
+  # since migration 014 will have created 'volume_folder' directly. This only
+  # applies to volume_defaults (as roxy didn't have any support for VMWare, so
+  # can't have any such backend.
+  if a['volume_defaults']['vmware']['volume_folder'].nil?
+    a['volume_defaults']['vmware']['volume_folder'] = a['volume_defaults']['vmware']['volume']
+  end
   a['volume_defaults']['vmware'].delete('volume')
 
   a['volumes'].each do |volume|


### PR DESCRIPTION
Copying straight from the template is nice, but can break when migrating
from a long time ago and then renaming a key.
