### PR TITLE
Make cinder.conf owned by root:cinder, instead of cinder:root

### DIFF
--- a/chef/cookbooks/cinder/recipes/common.rb
+++ b/chef/cookbooks/cinder/recipes/common.rb
@@ -214,8 +214,8 @@ end
 
 template "/etc/cinder/cinder.conf" do
   source "cinder.conf.erb"
-  owner node[:cinder][:user]
-  group "root"
+  owner "root"
+  group node[:cinder][:group]
   mode 0640
   variables(
     :bind_host => bind_host,


### PR DESCRIPTION
We don't want the cinder user to be able to write the file.
