### PR TITLE
Create directory when using local file backend

### DIFF
--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -43,6 +43,8 @@ def make_loopback_file(node, volume)
   max_fsize = ((`df -Pk #{encl_dir}`.split("\n")[1].split(" ")[3].to_i * 1024) * 0.90).to_i rescue 0
   fsize = max_fsize if fsize > max_fsize
 
+  FileUtils.mkdir_p(fdir) unless File.exists?(fdir)
+
   bash "Create local volume file #{fname}" do
     code "truncate -s #{fsize} #{fname}"
     not_if do


### PR DESCRIPTION
The directory where the local file will be created with "truncate -s"
must exist. Otherwise we get:

bash[Create local volume file
/var/lib/cinder123/mylocalfile](cinder::volume line 46) had an error:
Mixlib::ShellOut::ShellCommandFailed: Expected process to exit with [0],
but received '1'
## ---- Begin output of "bash" "/tmp/chef-script20150119-32704-1kp70a0"

STDOUT:
STDERR: truncate: cannot open `/var/lib/cinder123/mylocalfile' for ...
