### PR TITLE
Point auth_uri to the public endpoint

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -2724,7 +2724,7 @@ connection=<%= @sql_connection %>
 #auth_protocol=https
 
 # Complete public Identity API endpoint (string value)
-auth_uri = <%= @keystone_settings['internal_auth_url'] %>
+auth_uri = <%= @keystone_settings['public_auth_url'] %>
 
 # Complete admin Identity API endpoint. This should specify
 # the unversioned root endpoint e.g. https://localhost:35357/


### PR DESCRIPTION
The internal one is on the admin network and might
not be reachable.