### PR TITLE
Do not fail when OSD nodes are temporarily off

### DIFF
--- a/chef/cookbooks/cinder/recipes/ceph.rb
+++ b/chef/cookbooks/cinder/recipes/ceph.rb
@@ -37,9 +37,17 @@ if has_internal
   if ceph_servers.length > 0
     include_recipe "ceph::keyring"
   else
-    message = "Ceph was not deployed with Crowbar yet!"
-    Chef::Log.fatal(message)
-    raise message
+    # If we don't have any osd from our query, it could be because the
+    # osd nodes temporarily lost the role (while rebooting, for instance).
+    # So check if the ceph setup was done once already, to decide whether
+    # to fail or just to emit a warning.
+    if File.exists?("/etc/ceph/ceph.client.admin.keyring")
+      Chef::Log.warn("Ceph nodes seem to not be running; RBD backends might not work.")
+    else
+      message = "Ceph was not deployed with Crowbar yet!"
+      Chef::Log.fatal(message)
+      raise message
+    end
   end
 end
 


### PR DESCRIPTION
When OSD nodes are, for instance, rebooting, they lose their ceph-osd
role. So our query to check whether ceph was deployed is kind of wrong.

If we don't find any OSD node, then we check if the ceph setup was
likely done (by checking for /etc/ceph/ceph.client.admin.keyring), and
if yes, we just print a warning.