### PR TITLE
Adjust Eternus DX configuration options

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -1062,12 +1062,16 @@ iscsi_target_prefix = iqn.2001-07.com.vnx
     <% when "vmax" -%>
 iscsi_target_prefix = iqn.1992-04.com.em
     <% end -%>
+<% elsif volume['backend_driver'] == 'eternus' -%>
+iscsi_target_prefix = iqn.2000-09.com.fujitsu
 <% end -%>
 
 # The IP address that the iSCSI daemon is listening on (string
 # value)
 <% if volume['backend_driver'] == 'emc' -%>
 iscsi_ip_address = <%= volume["emc"]["emc_ecom_server_ip"] %>
+<% elsif volume['backend_driver'] == 'eternus' -%>
+iscsi_ip_address = <%= volume["eternus"]["iscsi_ip"] -%>
 <% end -%>
 
 # The port that the iSCSI daemon is listening on (integer

--- a/chef/cookbooks/cinder/templates/default/cinder_eternus_dx_config.xml.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder_eternus_dx_config.xml.erb
@@ -1,9 +1,9 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <FUJITSU>
-<EternusIP><%= @eternus_params["ip"] %></EternusIP>
-<EternusPort><%= @eternus_params["port"] %></EternusPort>
-<EternusUser><%= @eternus_params["user"] %></EternusUser>
-<EternusPassword><%= @eternus_params["password"] %></EternusPassword>
-<EternusPool><%= @eternus_params["pool"] %></EternusPool>
-<EternusISCSIIP><% if @eternus_params["protocol"] == "iscsi" %><%= @eternus_params["iscsi_ip"] %><% end %></EternusISCSIIP>
+<EcomServerIp><%= @eternus_params["ip"] %></EcomServerIp>
+<EcomServerPort><%= @eternus_params["port"] %></EcomServerPort>
+<EcomUserName><%= @eternus_params["user"] %></EcomUserName>
+<EcomPassword><%= @eternus_params["password"] %></EcomPassword>
+<SnapPool><%= @eternus_params["pool"] %></SnapPool>
+<Timeout>10</Timeout>
 </FUJITSU>

--- a/crowbar_framework/config/locales/cinder/en.yml
+++ b/crowbar_framework/config/locales/cinder/en.yml
@@ -85,7 +85,7 @@ en:
               port: 'Port for SMI-S'
               user: 'Username for SMI-S'
               password: 'Password for SMI-S'
-              pool: 'Pool Name'
+              pool: 'Snapshot (Thick/RAID Group) Pool Name'
               iscsi_ip: 'iSCSI IP'
             manual:
               config: 'Options'


### PR DESCRIPTION
With Juno the driver changed in an incompatible way. Adjusting
parameters to the new format.