### PR TITLE
HA: Set Optional ordering for Cinder startup

### DIFF
--- a/chef/cookbooks/cinder/recipes/controller_ha.rb
+++ b/chef/cookbooks/cinder/recipes/controller_ha.rb
@@ -64,4 +64,11 @@ pacemaker_clone "cl-#{group_name}" do
   only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
 end
 
+crowbar_pacemaker_order_only_existing "o-cl-#{group_name}" do
+  ordering [ "postgresql", "rabbitmq", "cl-keystone", "cl-#{group_name}" ]
+  score "Optional"
+  action :create
+  only_if { CrowbarPacemakerHelper.is_cluster_founder?(node) }
+end
+
 crowbar_pacemaker_sync_mark "create-cinder_ha_resources"


### PR DESCRIPTION
Cinder depends on Keystone and RabbitMQ to be started first.