### PR TITLE
fix check for nfs storage protocol

### DIFF
--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -186,7 +186,7 @@ node[:cinder][:volumes].each_with_index do |volume, volid|
         mode "0640"
         action :create
         notifies :restart, "service[cinder-volume]"
-        only_if volume[:netapp][:storage_protocol] == "nfs"
+        only_if { volume[:netapp][:storage_protocol] == "nfs" }
       end
 
     when volume[:backend_driver] == "eternus"


### PR DESCRIPTION
Failed to apply the proposal to: d52-54-02-77-77-02.v7.cloud.suse.de
Most recent logged lines from the Chef run:

[2015-03-02T13:06:17+00:00] INFO: Saving interfaces to crowbar_wall: {"eth0"=>{"addresses"=>["192.168.3.81/24"], "type"=>"physical", "gateway"=>"192.168.3.1"}}
[2015-03-02T13:06:18+00:00] INFO: Glance server at d52-54-01-77-77-01.v7.cloud.suse.de
[2015-03-02T13:06:19+00:00] INFO: Database server found at 192.168.3.82
[2015-03-02T13:06:19+00:00] INFO: RabbitMQ server found at 192.168.3.82
[2015-03-02T13:06:20+00:00] INFO: Keystone server found at d52-54-01-77-77-01.v7.cloud.suse.de

================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/cinder/recipes/volume.rb
================================================================================

ArgumentError
-------------
Invalid only_if/not_if command: true (TrueClass)

Cookbook Trace:
---------------
/var/chef/cache/cookbooks/cinder/recipes/volume.rb:189:in `block (2 levels) in from_file'
/var/chef/cache/cookbooks/cinder/recipes/volume.rb:182:in `block in from_file'
/var/chef/cache/cookbooks/cinder/recipes/volume.rb:157:in `each'
/var/chef/cache/cookbooks/cinder/recipes/volume.rb:157:in `each_with_index'
/var/chef/cache/cookbooks/cinder/recipes/volume.rb:157:in `from_file'

Relevant File Content:
----------------------
/var/chef/cache/cookbooks/cinder/recipes/volume.rb:

182: file "/etc/cinder/nfs_shares-#{backend_id}" do
183: content volume[:netapp][:nfs_shares]
184: owner "root"
185: group node[:cinder][:group]
186: mode "0640"
187: action :create
188: notifies :restart, "service[cinder-volume]"
189>> only_if volume[:netapp][:storage_protocol] == "nfs"
190: end
191:
192: when volume[:backend_driver] == "eternus"
193: template "/etc/cinder/cinder_eternus_dx_config-#{backend_id}.xml" do
194: source "cinder_eternus_dx_config.xml.erb"
195: owner "root"
196: group node[:cinder][:group]
197: mode 0640
198: variables(

[2015-03-02T13:06:20+00:00] ERROR: Running exception handlers
[2015-03-02T13:06:20+00:00] FATAL: Saving node information to /var/chef/cache/failed-run-data.json
[2015-03-02T13:06:20+00:00] ERROR: Exception handlers complete
[2015-03-02T13:06:20+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-stacktrace.out
[2015-03-02T13:06:20+00:00] FATAL: ArgumentError: Invalid only_if/not_if command: true (TrueClass)
d52-54-03-77-77-03.v7.cloud.suse.de
Most recent logged lines from the Chef run:

[2015-03-02T13:06:17+00:00] INFO: Saving interfaces to crowbar_wall: {"eth0"=>{"addresses"=>["192.168.3.84/24"], "type"=>"physical", "gateway"=>"192.168.3.1"}}
[2015-03-02T13:06:18+00:00] INFO: Glance server at d52-54-01-77-77-01.v7.cloud.suse.de
[2015-03-02T13:06:19+00:00] INFO: Database server found at 192.168.3.82
[2015-03-02T13:06:19+00:00] INFO: RabbitMQ server found at 192.168.3.82
[2015-03-02T13:06:20+00:00] INFO: Keystone server found at d52-54-01-77-77-01.v7.cloud.suse.de 