### PR TITLE
Fix hideShow toggle of password_field in Cinder backends

### DIFF
--- a/crowbar_framework/app/assets/javascripts/barclamps/cinder/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/cinder/application.js
@@ -81,6 +81,9 @@ $(document).ready(function($) {
       })
     );
 
+    // Make newly-added password fields toggleable
+    $('input[type=password]').hideShowPassword();
+
     // Fix up the select elements by reading the data-initial-value attributes
     // and setting it as value (aka selecting this option by default)
     $("#cinder_backends select[data-initial-value]").each(function(){ $(this).val($(this).data("initial-value").toString()); });


### PR DESCRIPTION
fixes [bsc#919963](https://bugzilla.suse.com/show_bug.cgi?id=919963)
The problem was that hideShowPassword() only ran after page load.
At that point the form elements of Cinder backends are not created yet.

The solution was to run this function also after the backend forms have been created.

__Note:__ I had a quick grep-and-look into the other barclamps and it seems as if none of them are affected by this bug because no form elements get created after page load there.

