### PR TITLE
On migrations, do not regenerate the secret_uuid if it already exists

### DIFF
--- a/chef/data_bags/crowbar/migrate/cinder/041_add_rbd_secret_uuid.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/041_add_rbd_secret_uuid.rb
@@ -2,6 +2,7 @@ def upgrade ta, td, a, d
   a['volume_defaults']['rbd']['secret_uuid'] = ta['volume_defaults']['rbd']['secret_uuid']
   a['volumes'].each do |volume|
     next if volume['backend_driver'] != 'rbd'
+    next unless volume['backend_driver']['secret_uuid'].nil?
     volume['rbd']['secret_uuid'] = `uuidgen`.strip
   end
   return a, d


### PR DESCRIPTION
This is required as the migration is also added in tex.

Required because of https://github.com/crowbar/barclamp-cinder/pull/254