### PR TITLE
Revoke chef calls

### DIFF
--- a/chef/cookbooks/cinder/recipes/volume.rb
+++ b/chef/cookbooks/cinder/recipes/volume.rb
@@ -43,10 +43,12 @@ def make_loopback_file(volume)
   max_fsize = ((`df -Pk #{encl_dir}`.split("\n")[1].split(" ")[3].to_i * 1024) * 0.90).to_i rescue 0
   fsize = max_fsize if fsize > max_fsize
 
-  Chef::Log.info("Create local volume file #{fname}")
-  cmd = ["truncate", "-s", "#{fsize}", fname]
-  create_local_file = Mixlib::ShellOut.new(cmd)
-  create_local_file.run_command
+  bash "Create local volume file #{fname}" do
+    code "truncate -s #{fsize} #{fname}"
+    not_if do
+      File.exists?(fname)
+    end
+  end
 end
 
 def setup_loopback_device(volume)
@@ -74,15 +76,10 @@ def make_loopback_volume(backend_id, volume)
 
   return if volume_exists(volname)
 
-  Chef::Log.info("Cinder: Using local file volume backing (#{backend_id})")
-  cmd = ["losetup", "-j", fname]
-  check_loopback_device = Mixlib::ShellOut.new(cmd)
-  loop_device = check_loopback_device.run_command.stdout.strip.split(':').first
-
-  Chef::Log.info("Create volume group #{volname}")
-  cmd = [ "vgcreate", volname, loop_device ]
-  create_volume_group = Mixlib::ShellOut.new(cmd)
-  create_volume_group.run_command
+  bash "Create volume group #{volname}" do
+    code "vgcreate #{volname} `losetup -j #{fname} | cut -f1 -d:`"
+    not_if "vgs #{volname}"
+  end
 end
 
 def make_volume(node, backend_id, volume)


### PR DESCRIPTION

Because jenkins jobs failing on SLE11SP3 we have to wait until we remove support for SLE11SP3 to replace this.

(revoke 954c64d7facfa9cac679166fb1e6b9f9aa19b294)