### PR TITLE
Set cinder cookbook name in metadata

### DIFF
--- a/chef/cookbooks/cinder/metadata.rb
+++ b/chef/cookbooks/cinder/metadata.rb
@@ -1,5 +1,6 @@
-maintainer       "User Unknown"
-maintainer_email "Unknown@Sample.com"
+name             "cinder"
+maintainer       "Crowbar project"
+maintainer_email "crowbar@googlegroups.com"
 license          "Apache 2.0"
 description      "Installs/Configures Cinder"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.me'))


### PR DESCRIPTION
Needed if the cookbook is used without the crowbar framework. I.e. using
the cookbook as berkshelf dependency.
Also update maintainer fields.