### PR TITLE
[tex] cinder: make rpc_response_timeout configurable

### DIFF
--- a/chef/cookbooks/cinder/templates/default/cinder.conf.erb
+++ b/chef/cookbooks/cinder/templates/default/cinder.conf.erb
@@ -172,6 +172,7 @@ rabbit_virtual_host=<%= @rabbit_settings[:vhost] %>
 
 # Seconds to wait for a response from a call. (integer value)
 #rpc_response_timeout=60
+rpc_response_timeout=<%= node[:cinder][:rpc_response_timeout] %>
 
 # A URL representing the messaging driver to use and its full
 # configuration. If not set, we fall back to the rpc_backend

--- a/chef/data_bags/crowbar/bc-template-cinder.json
+++ b/chef/data_bags/crowbar/bc-template-cinder.json
@@ -23,6 +23,7 @@
       "max_pool_size": 30,
       "max_overflow": 10,
       "pool_timeout": 30,
+      "rpc_response_timeout": 60,
       "pfs_deps": [
         "kpartx",
         "parted",
@@ -145,7 +146,7 @@
     "cinder": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 36,
+      "schema-revision": 37,
       "element_states": {
           "cinder-controller": [ "readying", "ready", "applying" ],
           "cinder-volume": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/bc-template-cinder.schema
+++ b/chef/data_bags/crowbar/bc-template-cinder.schema
@@ -32,6 +32,7 @@
             "max_pool_size": { "type": "int", "required": true },
             "max_overflow": { "type": "int", "required": true },
             "pool_timeout": { "type": "int", "required": true },
+            "rpc_response_timeout": { "type": "int", "required": true },
             "pfs_deps": { "type": "seq", "required": true, "sequence": [ { "type": "str" } ]},
             "use_multi_backend": { "type": "bool", "required": true },
             "volume_defaults": {

--- a/chef/data_bags/crowbar/migrate/cinder/037_add_rpc_response_timeout.rb
+++ b/chef/data_bags/crowbar/migrate/cinder/037_add_rpc_response_timeout.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.has_key? "rpc_response_timeout"
+    a["rpc_response_timeout"] = ta["rpc_response_timeout"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.has_key? "rpc_response_timeout"
+    a.delete("rpc_response_timeout")
+  end
+  return a, d
+end


### PR DESCRIPTION
When using i.e. a Hitachi storage backend, the timeout needs to be
increased.

(cherry picked from commit 3f701c80e91844f475a0021d0bde705b390459b1)